### PR TITLE
Add IP restriction middleware to block traffic

### DIFF
--- a/packages/backend/src/app.module.ts
+++ b/packages/backend/src/app.module.ts
@@ -1,5 +1,6 @@
-import { Module } from '@nestjs/common';
+import { MiddlewareConsumer, Module, NestModule } from '@nestjs/common';
 import { ConfigModule } from '@/config/config.module';
+import { IpRestrictMiddleware } from '@/common/middleware/ip-restrict.middleware';
 import { DatabaseModule } from '@/database/database.module';
 import { ZkVerifyModule } from './zkverify/zkverify.module';
 import { TransactionModule } from './transaction/transaction.module';
@@ -40,4 +41,8 @@ import { ScheduleModule } from '@nestjs/schedule';
     ScheduleModule.forRoot(),
   ],
 })
-export class AppModule {}
+export class AppModule implements NestModule {
+  configure(consumer: MiddlewareConsumer) {
+    consumer.apply(IpRestrictMiddleware).forRoutes('*');
+  }
+}

--- a/packages/backend/src/common/middleware/ip-restrict.middleware.ts
+++ b/packages/backend/src/common/middleware/ip-restrict.middleware.ts
@@ -1,0 +1,39 @@
+import { Injectable, NestMiddleware, Logger } from '@nestjs/common';
+import { Request, Response, NextFunction } from 'express';
+
+@Injectable()
+export class IpRestrictMiddleware implements NestMiddleware {
+  private readonly logger = new Logger(IpRestrictMiddleware.name);
+  private readonly restrictedIps: Set<string>;
+
+  constructor() {
+    const ips = process.env.RESTRICTED_IPS || '';
+    this.restrictedIps = new Set(
+      ips
+        .split(',')
+        .map((ip) => ip.trim())
+        .filter(Boolean),
+    );
+    if (this.restrictedIps.size > 0) {
+      this.logger.log(`Restricted IPs: ${[...this.restrictedIps].join(', ')}`);
+    }
+  }
+
+  use(req: Request, res: Response, next: NextFunction) {
+    if (this.restrictedIps.size === 0) return next();
+
+    const forwarded = req.headers['x-forwarded-for'];
+    const clientIp =
+      (typeof forwarded === 'string' ? forwarded.split(',')[0].trim() : null) ||
+      req.ip;
+
+    if (clientIp && this.restrictedIps.has(clientIp)) {
+      this.logger.warn(
+        `Blocked request from ${clientIp}: ${req.method} ${req.originalUrl}`,
+      );
+      return res.status(403).json({ message: 'Forbidden' });
+    }
+
+    next();
+  }
+}


### PR DESCRIPTION
## Summary
- Added a lightweight NestJS middleware that reads `RESTRICTED_IPS` env var and blocks requests from those IPs with 403
- `RESTRICTED_IPS` env var already set on production Cloud Run

## Test plan
- [ ] Verify backend starts without `RESTRICTED_IPS` set (no-op middleware)
- [ ] Verify requests from restricted IPs return 403
- [ ] Verify normal requests pass through
- [ ] Check Cloud Run logs after deploy for blocked bot requests