### PR TITLE
Add claim deadline: rewards expire after 1 week

### DIFF
--- a/packages/backend/src/reward/claim.controller.ts
+++ b/packages/backend/src/reward/claim.controller.ts
@@ -20,7 +20,13 @@ import { User } from '@/generated/prisma/client';
 import { RewardService } from './reward.service';
 import { ZenTransferService } from './zen-transfer.service';
 import { PrismaService } from '@/database/prisma.service';
-import { ClaimRequest, ClaimResponse, ClaimSummary } from '@polypay/shared';
+import {
+  ClaimRequest,
+  ClaimResponse,
+  ClaimSummary,
+  isClaimExpired,
+  getClaimDeadline,
+} from '@polypay/shared';
 import { isAddress } from 'viem';
 
 @ApiTags('claims')
@@ -92,6 +98,13 @@ export class ClaimController {
 
     if (weekData.isClaimed) {
       throw new BadRequestException(`Week ${week} already claimed`);
+    }
+
+    if (isClaimExpired(week)) {
+      const deadline = getClaimDeadline(week);
+      throw new BadRequestException(
+        `Claim for week ${week} has expired. Deadline was ${deadline.toISOString()}`,
+      );
     }
 
     if (weekData.rewardZen <= 0) {

--- a/packages/backend/src/reward/reward.service.ts
+++ b/packages/backend/src/reward/reward.service.ts
@@ -7,6 +7,8 @@ import {
   CAMPAIGN_START,
   TOTAL_CAMPAIGN_WEEKS,
   calculateRewardUsd,
+  getClaimDeadline,
+  isClaimExpired,
 } from '@polypay/shared';
 
 @Injectable()
@@ -141,6 +143,9 @@ export class RewardService {
       // Skip if no rank or rank > 100
       if (!rank || rank > 100) continue;
 
+      const expired = isClaimExpired(week);
+      const claimDeadline = getClaimDeadline(week).toISOString();
+
       // If already claimed, use data from ClaimHistory
       if (existingClaim) {
         claimableWeeks.push({
@@ -149,10 +154,12 @@ export class RewardService {
           rewardUsd: existingClaim.rewardUsd,
           rewardZen: existingClaim.rewardZen,
           isClaimed: true,
+          isExpired: expired,
+          claimDeadline,
           txHash: existingClaim.txHash,
         });
-      } else {
-        // Not claimed yet, calculate reward
+      } else if (!expired) {
+        // Not claimed yet and not expired, calculate reward
         const zenPrice = await this.priceService.getZenPriceForWeek(week);
         const rewardUsd = calculateRewardUsd(rank);
         const rewardZen = zenPrice > 0 ? rewardUsd / zenPrice : 0;
@@ -163,6 +170,8 @@ export class RewardService {
           rewardUsd,
           rewardZen,
           isClaimed: false,
+          isExpired: false,
+          claimDeadline,
         });
       }
     }

--- a/packages/shared/src/constants/campaign.ts
+++ b/packages/shared/src/constants/campaign.ts
@@ -9,6 +9,9 @@ export const TOTAL_CAMPAIGN_WEEKS = 2;
 // Weekly reward pool in USD
 export const WEEKLY_REWARD_POOL = 700;
 
+// Claim deadline: number of days after a week ends that rewards can still be claimed
+export const CLAIM_DEADLINE_DAYS = 7;
+
 // ==================== Reward Percentages ====================
 
 // Reward percentages by rank (top 1-5)
@@ -119,6 +122,24 @@ export function getAvailableWeeks(): number[] {
 export function isWeekAvailable(week: number): boolean {
   const availableWeeks = getAvailableWeeks();
   return availableWeeks.includes(week);
+}
+
+/**
+ * Get the claim deadline for a given week.
+ * Users must claim before this date or the reward expires.
+ */
+export function getClaimDeadline(week: number): Date {
+  const { end } = getWeekDateRange(week);
+  end.setDate(end.getDate() + CLAIM_DEADLINE_DAYS);
+  return end;
+}
+
+/**
+ * Check if a week's claim has expired
+ */
+export function isClaimExpired(week: number): boolean {
+  const deadline = getClaimDeadline(week);
+  return new Date() > deadline;
 }
 
 /**

--- a/packages/shared/src/types/reward.ts
+++ b/packages/shared/src/types/reward.ts
@@ -7,6 +7,8 @@ export interface ClaimableWeek {
   rewardUsd: number;
   rewardZen: number;
   isClaimed: boolean;
+  isExpired: boolean;
+  claimDeadline: string;
   txHash?: string;
 }
 


### PR DESCRIPTION
## Summary
- Added `CLAIM_DEADLINE_DAYS = 7` constant — rewards expire 1 week after becoming claimable
- Expired unclaimed weeks are excluded from the claim summary response
- `POST /api/claims` returns a 400 error if the claim deadline has passed
- `ClaimableWeek` type now includes `isExpired` and `claimDeadline` fields

## Deadline timeline
| Week | Claimable From | Claim Deadline |
|------|----------------|----------------|
| 1    | Feb 13         | Feb 20         |
| 2    | Feb 20         | Feb 27         |

## Test plan
- [ ] Verify `GET /api/claims/summary` excludes expired unclaimed weeks
- [ ] Verify `POST /api/claims` returns 400 for expired weeks
- [ ] Verify already-claimed weeks still show in summary with `isExpired` flag
- [ ] Verify unclaimed weeks within deadline are still claimable