### PR TITLE
perf: transpile @polypay/shared to reduce first load JS from 2.3MB to <500KB

### DIFF
--- a/packages/nextjs/next.config.ts
+++ b/packages/nextjs/next.config.ts
@@ -8,6 +8,7 @@ const __dirname = path.dirname(__filename);
 const nextConfig: NextConfig = {
   reactStrictMode: true,
   devIndicators: false,
+  transpilePackages: ["@polypay/shared"],
   typescript: {
     ignoreBuildErrors: false,
   },

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "target": "ES2020",
-    "module": "CommonJS",
-    "moduleResolution": "node",
+    "module": "ES2020",
+    "moduleResolution": "bundler",
     "declaration": true,
     "strict": true,
     "esModuleInterop": true,


### PR DESCRIPTION
Fix #197 

## Types of change

- [ ] Feature
- [ ] Bug
- [X] Enhancement

## Comments (optional)
Decrease size from:
<img width="483" height="291" alt="image" src="https://github.com/user-attachments/assets/93a54098-d52d-4956-954c-3b47265bbdc2" />

to:
<img width="494" height="293" alt="image" src="https://github.com/user-attachments/assets/45dce08c-5f47-4bec-a338-7e09c81b78f8" />
