### PR TITLE
Add gasless USDC deposit on Base (x402)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -21,6 +21,7 @@ PolyPay uses **zero-knowledge proofs** and **multi-chain deployment** (Horizen a
 * **Private Payments**: Salary amounts and recipients stay confidential
 * **Private Multisig**: Team approvals without exposing signer identities
 * **Flexible Payment Logic**: Single and batch transfers
+* **Gasless USDC Deposit (x402)**: Fund a multisig on Base with one signature, no ETH required — works for human users and AI agents via the [x402 protocol](https://www.x402.org/)
 
 ### Who Is It For?
 
@@ -40,3 +41,4 @@ PolyPay uses **zero-knowledge proofs** and **multi-chain deployment** (Horizen a
 * Fiat on/off-ramp integration
 * Escrow and milestone-based payments
 * Recurring transfers
+* Expand x402 to additional networks and tokens beyond USDC on Base

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -7,6 +7,7 @@
 - [Zero-Knowledge Implementation](zero-knowledge-implementation.md)
 - [ZK Authentication](zk-authentication.md)
 - [zkVerify, Horizen & Base Integration](zkverify-horizen-integration.md)
+- [Gasless USDC Deposits (x402)](x402-deposits.md)
 - [Architecture](architecture.md)
 - [Developer Documentation](developer-documentation/README.md)
   - [Getting Started](developer-documentation/getting-started.md)

--- a/docs/developer-documentation/api-documentation.md
+++ b/docs/developer-documentation/api-documentation.md
@@ -198,6 +198,16 @@ http://localhost:4000/api
 |--------|----------|-------------|---------------|
 | GET | `/claims/summary` | Get claim summary for all weeks | Yes |
 | POST | `/claims` | Claim weekly reward | Yes |
+
+#### x402 Gasless USDC Deposit (`/api/x402`)
+
+| Method | Endpoint | Description | Auth Required |
+|--------|----------|-------------|---------------|
+| GET | `/x402/deposit/:multisigAddress` | Returns HTTP 402 with x402 v1 payment requirements for the multisig | No |
+| POST | `/x402/deposit/:multisigAddress` | Settles an EIP-3009 USDC deposit through an x402 facilitator. Requires `X-PAYMENT` header with a base64 x402 v1 payment payload. | No |
+
+See [Gasless USDC Deposits (x402)](../x402-deposits.md) for the full integration guide, request/response shapes, supported networks, limits, and security model.
+
 ## Authentication
 
 PolyPay uses JWT (JSON Web Tokens) for authentication.
@@ -281,14 +291,22 @@ Content-Type: application/json
 | 201 | Created | Resource created successfully |
 | 400 | Bad Request | Invalid request data |
 | 401 | Unauthorized | Missing or invalid authentication |
+| 402 | Payment Required | x402 discovery response — caller must include a valid `X-PAYMENT` header to retry |
 | 403 | Forbidden | Insufficient permissions |
 | 404 | Not Found | Resource not found |
 | 409 | Conflict | Resource conflict (duplicate) |
+| 429 | Too Many Requests | Rate limit exceeded (per IP or per multisig) |
 | 500 | Internal Server Error | Server error |
 
 ## Rate Limiting
 
-Currently, there is no rate limiting on the API. This may be added in future versions.
+Most endpoints are not rate limited. The x402 deposit endpoint applies the following caps:
+
+| Scope | Limit |
+|-------|-------|
+| `GET /api/x402/deposit/:multisigAddress` per IP | 60 requests / 60s |
+| `POST /api/x402/deposit/:multisigAddress` per IP | 10 requests / 60s |
+| `POST /api/x402/deposit/:multisigAddress` per multisig | 30 requests / 60s |
 
 ## CORS Configuration
 

--- a/docs/developer-documentation/getting-started.md
+++ b/docs/developer-documentation/getting-started.md
@@ -73,12 +73,16 @@ yarn start:frontend
 
 ### Environment Variables
 
-| Variable                   | Description                    |
-| -------------------------- | ------------------------------ |
-| `DATABASE_URL`             | PostgreSQL connection string   |
-| `RELAYER_WALLET_KEY`       | Private key for relayer wallet |
-| `RELAYER_ZKVERIFY_API_KEY` | API key from zkVerify          |
-| `NEXT_PUBLIC_API_URL`      | Backend API URL                |
+| Variable                          | Description                                                                                                |
+| --------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| `DATABASE_URL`                    | PostgreSQL connection string                                                                               |
+| `RELAYER_WALLET_KEY`              | Private key for relayer wallet                                                                             |
+| `RELAYER_ZKVERIFY_API_KEY`        | API key from zkVerify                                                                                      |
+| `NEXT_PUBLIC_API_URL`             | Backend API URL                                                                                            |
+| `FEATURE_X402_DEPOSIT`            | `true` to enable the x402 gasless deposit endpoint and UI (default `false`)                                |
+| `X402_FACILITATOR_URL`            | x402 facilitator base URL — `https://facilitator.payai.network` (default, supports Base mainnet + Sepolia, no API key)                  |
+| `X402_FACILITATOR_BEARER_TOKEN`   | Optional bearer token; leave empty for facilitators that do not require auth (e.g. PayAI)                |
+| `NEXT_PUBLIC_FEATURE_X402_DEPOSIT`| Frontend flag to render the Deposit button in the Portfolio panel (matches backend flag)                  |
 
 
 ### User Workflow

--- a/docs/how-to-use-polipay-app.md
+++ b/docs/how-to-use-polipay-app.md
@@ -8,6 +8,7 @@ Polypay app beta v0.1 is an initial release of the Polypay platform. It is a web
 - Create and manage a multisig account
 - Hide signers(multisig account owners) identities with ZK proofs
 - Execute payroll payments: Transfer funds to multiple recipients
+- **Deposit USDC into a multisig gaslessly via x402 (Base only)**
 - View transaction history
 - View multisig account balance
 - View multisig account address
@@ -51,3 +52,7 @@ Create a new multisig account by adding signer commitments and setting the thres
 Send funds to single or multiple recipients with ZK proof generation.
 
 ![Transfer](.gitbook/assets/transfer.png)
+
+### Gasless USDC Deposit (x402)
+
+Open the Portfolio panel of a Base multisig and click **Deposit** to fund the multisig with USDC in a single signature, no ETH required. The flow uses the [x402 protocol](https://www.x402.org/) and works for human users and AI agents alike. See [Gasless USDC Deposits (x402)](x402-deposits.md) for the full guide and developer integration.

--- a/docs/x402-deposits.md
+++ b/docs/x402-deposits.md
@@ -1,0 +1,161 @@
+# Gasless USDC Deposits (x402)
+
+PolyPay supports the [x402 payment protocol](https://www.x402.org/) for funding multisig accounts on Base without holding ETH. The depositor signs a single off-chain authorization; an x402 facilitator submits the on-chain transfer and pays the gas.
+
+## What is x402 deposit?
+
+x402 is an open HTTP-native payment standard (HTTP 402 + EIP-3009 stablecoin transfer) designed for both human users and AI agents. PolyPay exposes a public x402-compliant endpoint per multisig: anyone with USDC on Base can fund a PolyPay multisig in a single signature, with zero gas, no API key, and no PolyPay account.
+
+Same endpoint, two audiences:
+
+- **Human users** open the Portfolio panel of any Base multisig in the PolyPay app and click **Deposit** — one wallet signature funds the multisig.
+- **AI agents and external scripts** call the endpoint with any standard x402 client library — autonomous, programmatic, ecosystem-compatible.
+
+## For users
+
+### Prerequisites
+
+- A wallet (MetaMask, Coinbase Wallet, Rainbow, etc.) connected to **Base mainnet** or **Base Sepolia**.
+- USDC in the wallet (≥ 1 USDC).
+- A PolyPay multisig deployed on Base mainnet or Base Sepolia.
+
+> No ETH required. The facilitator pays the on-chain gas.
+
+### Flow
+
+1. Open the PolyPay app and select your Base multisig.
+2. Click the **Portfolio** in the top-right to open the drawer.
+3. In the action row (Transfer / Receive / Deposit), click **Deposit**.
+4. Enter an amount between **1 and 10,000 USDC**.
+5. Click **Deposit** and approve the wallet signature prompt (one signature, off-chain).
+6. The success screen displays a Basescan transaction link. The USDC arrives in the multisig within seconds.
+
+If your wallet is connected to a different chain than the multisig, the modal shows a "Switch network" prompt.
+
+## For agents and developers
+
+### Endpoint
+
+```
+GET  /api/x402/deposit/{multisigAddress}   → 402 Payment Required + x402 v1 discovery
+POST /api/x402/deposit/{multisigAddress}   → 200 OK + on-chain settlement receipt
+```
+
+`{multisigAddress}` is the EVM address of a registered PolyPay multisig on Base mainnet (8453) or Base Sepolia (84532). Lookup is case-insensitive.
+
+### Request
+
+POST body is optional metadata only:
+
+```json
+{ "memo": "treasury top-up" }   // memo ≤ 280 chars, body may also be {}
+```
+
+The actual payment is in the `X-PAYMENT` header — a base64-encoded x402 v1 payment payload (signed EIP-3009 `transferWithAuthorization` from the agent's wallet to the multisig).
+
+### Response
+
+```json
+{
+  "principalTxHash": "0xabc...",
+  "multisigAddress": "0x...",
+  "depositedAmount": "1000000",
+  "chainId": 8453,
+  "status": "SETTLED",
+  "timestamp": "2026-04-24T10:30:00.000Z"
+}
+```
+
+Amount is in 6-decimal USDC base units (`1000000` = 1 USDC).
+
+### Quickstart with `x402-fetch` (TypeScript)
+
+```ts
+import { wrapFetchWithPayment } from "x402-fetch";
+import { privateKeyToAccount } from "viem/accounts";
+
+const account = privateKeyToAccount(process.env.AGENT_PRIVATE_KEY as `0x${string}`);
+const fetchWithPay = wrapFetchWithPayment(fetch, account);
+
+const res = await fetchWithPay(
+  "https://api.polypay.xyz/api/x402/deposit/0xYOUR_POLYPAY_MULTISIG",
+  {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ memo: "agent run" }),
+  },
+);
+
+const { principalTxHash, status } = await res.json();
+console.log(status, principalTxHash);
+```
+
+The `x402-fetch` library handles discovery, signing, and the X-PAYMENT header automatically. Equivalent libraries exist for Python (`x402`), Rust (`x402-rs`), and Axios (`x402-axios`).
+
+### Raw protocol (curl)
+
+```bash
+# 1. Discovery
+curl https://api.polypay.xyz/api/x402/deposit/0xMULTISIG
+
+# 2. Sign EIP-3009 with your wallet (off-chain)
+# 3. POST with X-PAYMENT header
+curl -X POST https://api.polypay.xyz/api/x402/deposit/0xMULTISIG \
+  -H "Content-Type: application/json" \
+  -H "X-PAYMENT: <base64-x402-v1-payload>" \
+  -d '{}'
+```
+
+## Supported networks and limits
+
+| Network | Chain ID | USDC contract |
+|---|---|---|
+| Base mainnet | 8453 | `0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913` |
+| Base Sepolia | 84532 | `0x036CbD53842c5426634e7929541eC2318f3dCF7e` |
+
+| Limit | Value |
+|---|---|
+| Minimum deposit | 1 USDC |
+| Maximum deposit | 10,000 USDC |
+| Per IP, GET discovery | 60 req / 60s |
+| Per IP, POST deposit | 10 req / 60s |
+| Per multisig, POST deposit | 30 req / 60s |
+| Authorization validity | 5 minutes |
+
+## Security model
+
+The x402 deposit endpoint is non-custodial. PolyPay never holds the USDC and never has the authority to redirect it.
+
+- **Recipient is locked**: the EIP-3009 signature binds the transfer to the exact `to = multisigAddress`. Neither PolyPay nor the facilitator can submit the transfer to a different address — the USDC contract verifies the signed recipient on-chain.
+- **Amount is locked**: `value` is part of the signed message. No party can inflate or reduce the deposit.
+- **Replay protection**: each signature uses a unique 32-byte nonce. The USDC contract marks the nonce consumed on settlement; PolyPay also tracks nonces in its own DB to fail fast on duplicates.
+- **No ETH custody**: the facilitator pays gas from its own wallet. PolyPay's relayer wallet is not involved in this flow.
+
+The worst-case behaviour of a malicious or failed facilitator is denial of service — a deposit may fail and need to be retried, but funds cannot be stolen or redirected.
+
+## FAQ
+
+**Why is there no platform fee?**
+The marketing value is the x402 listing and the gasless UX, not fee revenue. The facilitator absorbs the on-chain gas; PolyPay subsidises an effectively zero per-deposit cost.
+
+**Which facilitator do you use?**
+PolyPay defaults to [PayAI](https://facilitator.payai.network), an x402-compliant facilitator that supports both Base mainnet and Base Sepolia and requires no API key. The facilitator URL is configurable through a single environment variable, so PolyPay can switch to Coinbase CDP, Treasure, Primer, or any other x402-spec facilitator without code changes.
+
+**Can the facilitator steal my USDC?**
+No. The signed authorization locks both the recipient and the amount. The facilitator can only submit the transaction as signed; it cannot redirect funds.
+
+**What if the facilitator is down?**
+The deposit attempt fails and the user can retry — either later when the facilitator recovers, or PolyPay can switch facilitator via configuration. No funds are lost; the on-chain authorization is not consumed unless settlement succeeds.
+
+**Does this work on Horizen?**
+No. x402 currently targets EVM chains supported by facilitators (predominantly Base, Polygon, Solana). On Horizen, deposit funds via direct on-chain `USDC.transfer` from a wallet holding native gas.
+
+**Is this for humans or for agents?**
+Both. The same endpoint serves the in-app Deposit modal and any external x402 client.
+
+## See also
+
+- [API Documentation](developer-documentation/api-documentation.md) — full endpoint reference
+- [How to use PolyPay App](how-to-use-polipay-app.md) — end-user guide
+- [x402 Protocol Specification](https://www.x402.org/) — official protocol docs
+- [PayAI Facilitator](https://facilitator.payai.network) — default facilitator used by PolyPay

--- a/packages/backend/.env.example
+++ b/packages/backend/.env.example
@@ -40,3 +40,7 @@ TELEGRAM_CHAT_ID="your-telegram-chat-id-here"
 # Snag Solutions (loyalty rewards)
 SNAG_API_KEY="your-snag-api-key-here"
 SNAG_RULE_ID="your-snag-rule-id-here"
+
+# x402 gasless USDC deposit (optional)
+FEATURE_X402_DEPOSIT=false
+X402_FACILITATOR_URL=https://facilitator.payai.network

--- a/packages/backend/prisma/migrations/20260424101541_x402_slim_schema/migration.sql
+++ b/packages/backend/prisma/migrations/20260424101541_x402_slim_schema/migration.sql
@@ -1,0 +1,31 @@
+-- v2 schema for x402 deposits: single-signature, no fee, status PENDING|SETTLED|FAILED.
+-- Idempotent: drops any v1 leftovers (table + enum + indexes) before recreating.
+-- Safe because v1 schema was never deployed to production.
+
+DROP INDEX IF EXISTS "x402_deposits_fee_auth_nonce_key";
+DROP TABLE IF EXISTS "x402_deposits";
+DROP TYPE IF EXISTS "X402DepositStatus";
+
+CREATE TYPE "X402DepositStatus" AS ENUM ('PENDING', 'SETTLED', 'FAILED');
+
+CREATE TABLE "x402_deposits" (
+    "id" TEXT NOT NULL,
+    "buyer_address" TEXT NOT NULL,
+    "multisig_address" TEXT NOT NULL,
+    "principal_amount" TEXT NOT NULL,
+    "principal_auth_nonce" TEXT NOT NULL,
+    "principal_tx_hash" TEXT,
+    "chain_id" INTEGER NOT NULL,
+    "status" "X402DepositStatus" NOT NULL DEFAULT 'PENDING',
+    "error_message" TEXT,
+    "memo" TEXT,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "x402_deposits_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "x402_deposits_principal_auth_nonce_key" ON "x402_deposits"("principal_auth_nonce");
+CREATE INDEX "x402_deposits_multisig_address_idx" ON "x402_deposits"("multisig_address");
+CREATE INDEX "x402_deposits_buyer_address_idx" ON "x402_deposits"("buyer_address");
+CREATE INDEX "x402_deposits_created_at_idx" ON "x402_deposits"("created_at");

--- a/packages/backend/prisma/schema.prisma
+++ b/packages/backend/prisma/schema.prisma
@@ -279,6 +279,32 @@ model WeeklyZenPrice {
   @@map("weekly_zen_prices")
 }
 
+model X402Deposit {
+  id                 String            @id @default(cuid())
+  buyerAddress       String            @map("buyer_address")
+  multisigAddress    String            @map("multisig_address")
+  principalAmount    String            @map("principal_amount")
+  principalAuthNonce String            @unique @map("principal_auth_nonce")
+  principalTxHash    String?           @map("principal_tx_hash")
+  chainId            Int               @map("chain_id")
+  status             X402DepositStatus @default(PENDING)
+  errorMessage       String?           @map("error_message")
+  memo               String?
+  createdAt          DateTime          @default(now()) @map("created_at")
+  updatedAt          DateTime          @updatedAt @map("updated_at")
+
+  @@index([multisigAddress])
+  @@index([buyerAddress])
+  @@index([createdAt])
+  @@map("x402_deposits")
+}
+
+enum X402DepositStatus {
+  PENDING
+  SETTLED
+  FAILED
+}
+
 enum TxType {
   TRANSFER
   ADD_SIGNER

--- a/packages/backend/src/app.module.ts
+++ b/packages/backend/src/app.module.ts
@@ -21,6 +21,9 @@ import { QuestModule } from './quest/quest.module';
 import { RewardModule } from './reward/reward.module';
 import { BalanceAlertModule } from './balance-alert/balance-alert.module';
 import { ScheduleModule } from '@nestjs/schedule';
+import { X402Module } from './x402/x402.module';
+
+const featureX402 = process.env.FEATURE_X402_DEPOSIT === 'true';
 
 @Module({
   imports: [
@@ -47,6 +50,7 @@ import { ScheduleModule } from '@nestjs/schedule';
     RewardModule,
     BalanceAlertModule,
     ScheduleModule.forRoot(),
+    ...(featureX402 ? [X402Module] : []),
   ],
 })
 export class AppModule implements NestModule {

--- a/packages/backend/src/config/config.keys.ts
+++ b/packages/backend/src/config/config.keys.ts
@@ -28,4 +28,9 @@ export const CONFIG_KEYS = {
   // Snag Solutions
   SNAG_API_KEY: 'snag.apiKey',
   SNAG_RULE_ID: 'snag.ruleId',
+
+  // x402 gasless USDC deposit
+  X402_ENABLED: 'x402.enabled',
+  X402_FACILITATOR_URL: 'x402.facilitatorUrl',
+  X402_FACILITATOR_BEARER_TOKEN: 'x402.facilitatorBearerToken',
 } as const;

--- a/packages/backend/src/config/config.module.ts
+++ b/packages/backend/src/config/config.module.ts
@@ -6,6 +6,7 @@ import jwtConfig from './jwt.config';
 import relayerConfig from './relayer.config';
 import telegramConfig from './telegram.config';
 import snagConfig from './snag.config';
+import x402Config from './x402.config';
 import { validationSchema } from './env.validation';
 
 @Module({
@@ -19,6 +20,7 @@ import { validationSchema } from './env.validation';
         relayerConfig,
         telegramConfig,
         snagConfig,
+        x402Config,
       ],
       envFilePath: ['.env.local', '.env'],
       cache: true,

--- a/packages/backend/src/config/env.validation.ts
+++ b/packages/backend/src/config/env.validation.ts
@@ -44,4 +44,13 @@ export const validationSchema = Joi.object({
   // Snag Solutions - optional
   SNAG_API_KEY: Joi.string().optional(),
   SNAG_RULE_ID: Joi.string().optional(),
+
+  // x402 gasless deposit (optional; module loads only when FEATURE_X402_DEPOSIT=true)
+  FEATURE_X402_DEPOSIT: Joi.string().valid('true', 'false').default('false'),
+  X402_FACILITATOR_URL: Joi.alternatives().conditional('FEATURE_X402_DEPOSIT', {
+    is: 'true',
+    then: Joi.string().uri().required(),
+    otherwise: Joi.string().uri().optional(),
+  }),
+  X402_FACILITATOR_BEARER_TOKEN: Joi.string().optional().allow(''),
 });

--- a/packages/backend/src/config/x402.config.ts
+++ b/packages/backend/src/config/x402.config.ts
@@ -1,0 +1,8 @@
+import { registerAs } from '@nestjs/config';
+
+export default registerAs('x402', () => ({
+  enabled: process.env.FEATURE_X402_DEPOSIT === 'true',
+  facilitatorUrl:
+    process.env.X402_FACILITATOR_URL ?? 'https://facilitator.payai.network',
+  facilitatorBearerToken: process.env.X402_FACILITATOR_BEARER_TOKEN ?? '',
+}));

--- a/packages/backend/src/main.ts
+++ b/packages/backend/src/main.ts
@@ -23,7 +23,7 @@ async function bootstrap() {
   app.enableCors({
     origin: configService.get<string>('app.corsOrigin'),
     methods: ['GET', 'POST', 'PUT', 'DELETE', 'PATCH'],
-    allowedHeaders: ['Content-Type', 'Authorization'],
+    allowedHeaders: ['Content-Type', 'Authorization', 'X-PAYMENT'],
   });
 
   // API prefix

--- a/packages/backend/src/x402/constants.ts
+++ b/packages/backend/src/x402/constants.ts
@@ -1,0 +1,12 @@
+/** Minimum deposit per request: 1 USDC (6 decimals). */
+export const MIN_DEPOSIT: bigint = 1_000_000n;
+
+/** Maximum deposit per request: 10,000 USDC (6 decimals). */
+export const MAX_DEPOSIT: bigint = 10_000_000_000n;
+
+/** Authorization must remain valid at least this long when we receive it. */
+export const AUTH_BUFFER_SECONDS = 60;
+
+/** Per-multisig: max deposits in a 60s window. */
+export const PER_MULTISIG_RATE_LIMIT_COUNT = 30;
+export const PER_MULTISIG_RATE_LIMIT_WINDOW_MS = 60_000;

--- a/packages/backend/src/x402/dto/deposit-request.dto.ts
+++ b/packages/backend/src/x402/dto/deposit-request.dto.ts
@@ -1,0 +1,8 @@
+import { IsOptional, IsString, MaxLength } from 'class-validator';
+
+export class DepositRequestDto {
+  @IsOptional()
+  @IsString()
+  @MaxLength(280)
+  memo?: string;
+}

--- a/packages/backend/src/x402/eip712-domain-cache.service.ts
+++ b/packages/backend/src/x402/eip712-domain-cache.service.ts
@@ -1,0 +1,96 @@
+import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
+import { createPublicClient, http } from 'viem';
+import {
+  USDC_TOKEN,
+  getChainById,
+  X402_SUPPORTED_CHAIN_IDS,
+} from '@polypay/shared';
+
+const NAME_ABI = [
+  {
+    name: 'name',
+    type: 'function',
+    stateMutability: 'view',
+    inputs: [],
+    outputs: [{ type: 'string' }],
+  },
+  {
+    name: 'version',
+    type: 'function',
+    stateMutability: 'view',
+    inputs: [],
+    outputs: [{ type: 'string' }],
+  },
+] as const;
+
+export interface Eip712Domain {
+  name: string;
+  version: string;
+  chainId: number;
+  verifyingContract: `0x${string}`;
+}
+
+@Injectable()
+export class Eip712DomainCacheService implements OnModuleInit {
+  private readonly logger = new Logger(Eip712DomainCacheService.name);
+  private readonly cache = new Map<number, Eip712Domain>();
+
+  async onModuleInit(): Promise<void> {
+    for (const chainId of X402_SUPPORTED_CHAIN_IDS) {
+      const verifyingContract = USDC_TOKEN.addresses[chainId] as
+        | `0x${string}`
+        | undefined;
+      if (!verifyingContract) {
+        this.logger.warn(
+          `USDC address missing for chainId ${chainId}, skipping domain prefetch`,
+        );
+        continue;
+      }
+      try {
+        const domain = await this.readDomainFromChain(
+          chainId,
+          verifyingContract,
+        );
+        this.cache.set(chainId, domain);
+        this.logger.log(
+          `Cached EIP-712 domain for chain ${chainId}: name="${domain.name}" version="${domain.version}"`,
+        );
+      } catch (err) {
+        this.logger.error(
+          `Failed to read EIP-712 domain for chain ${chainId}: ${
+            (err as Error).message
+          }`,
+        );
+      }
+    }
+  }
+
+  get(chainId: number): Eip712Domain {
+    const cached = this.cache.get(chainId);
+    if (!cached) {
+      throw new Error(`EIP-712 domain not cached for chain ${chainId}`);
+    }
+    return cached;
+  }
+
+  private async readDomainFromChain(
+    chainId: number,
+    verifyingContract: `0x${string}`,
+  ): Promise<Eip712Domain> {
+    const chain = getChainById(chainId);
+    const client = createPublicClient({ chain, transport: http() });
+    const [name, version] = await Promise.all([
+      client.readContract({
+        address: verifyingContract,
+        abi: NAME_ABI,
+        functionName: 'name',
+      }),
+      client.readContract({
+        address: verifyingContract,
+        abi: NAME_ABI,
+        functionName: 'version',
+      }),
+    ]);
+    return { name, version, chainId, verifyingContract };
+  }
+}

--- a/packages/backend/src/x402/utils/eip3009-validator.ts
+++ b/packages/backend/src/x402/utils/eip3009-validator.ts
@@ -1,0 +1,45 @@
+import { recoverTypedDataAddress, serializeSignature } from 'viem';
+import type { Eip3009Authorization } from '@polypay/shared';
+import type { Eip712Domain } from '../eip712-domain-cache.service';
+
+const TRANSFER_WITH_AUTHORIZATION_TYPES = {
+  TransferWithAuthorization: [
+    { name: 'from', type: 'address' },
+    { name: 'to', type: 'address' },
+    { name: 'value', type: 'uint256' },
+    { name: 'validAfter', type: 'uint256' },
+    { name: 'validBefore', type: 'uint256' },
+    { name: 'nonce', type: 'bytes32' },
+  ],
+} as const;
+
+export async function recoverEip3009Signer(
+  auth: Eip3009Authorization,
+  domain: Eip712Domain,
+): Promise<string> {
+  const signature = serializeSignature({
+    r: auth.r as `0x${string}`,
+    s: auth.s as `0x${string}`,
+    v: BigInt(auth.v),
+  });
+
+  return recoverTypedDataAddress({
+    domain: {
+      name: domain.name,
+      version: domain.version,
+      chainId: domain.chainId,
+      verifyingContract: domain.verifyingContract,
+    },
+    types: TRANSFER_WITH_AUTHORIZATION_TYPES,
+    primaryType: 'TransferWithAuthorization',
+    message: {
+      from: auth.from as `0x${string}`,
+      to: auth.to as `0x${string}`,
+      value: BigInt(auth.value),
+      validAfter: BigInt(auth.validAfter),
+      validBefore: BigInt(auth.validBefore),
+      nonce: auth.nonce as `0x${string}`,
+    },
+    signature,
+  });
+}

--- a/packages/backend/src/x402/utils/x402-payment.ts
+++ b/packages/backend/src/x402/utils/x402-payment.ts
@@ -1,0 +1,41 @@
+import { BadRequestException } from '@nestjs/common';
+import type { X402V1PaymentPayload } from '@polypay/shared';
+
+export function decodeXPaymentHeader(header: string): X402V1PaymentPayload {
+  let parsed: unknown;
+  try {
+    const json = Buffer.from(header.trim(), 'base64').toString('utf8');
+    parsed = JSON.parse(json);
+  } catch {
+    throw new BadRequestException('Malformed X-PAYMENT header');
+  }
+
+  if (!isX402V1PaymentPayload(parsed)) {
+    throw new BadRequestException(
+      'Unsupported X-PAYMENT payload (expected x402 v1)',
+    );
+  }
+  return parsed;
+}
+
+function isX402V1PaymentPayload(x: unknown): x is X402V1PaymentPayload {
+  if (typeof x !== 'object' || x === null) return false;
+  const o = x as Record<string, unknown>;
+  if (o.x402Version !== 1 || o.scheme !== 'exact') return false;
+  if (typeof o.network !== 'string') return false;
+  const inner = o.payload;
+  if (typeof inner !== 'object' || inner === null) return false;
+  const p = inner as Record<string, unknown>;
+  if (typeof p.signature !== 'string') return false;
+  const auth = p.authorization;
+  if (typeof auth !== 'object' || auth === null) return false;
+  const a = auth as Record<string, unknown>;
+  return (
+    typeof a.from === 'string' &&
+    typeof a.to === 'string' &&
+    typeof a.value === 'string' &&
+    typeof a.validAfter === 'string' &&
+    typeof a.validBefore === 'string' &&
+    typeof a.nonce === 'string'
+  );
+}

--- a/packages/backend/src/x402/x402.controller.ts
+++ b/packages/backend/src/x402/x402.controller.ts
@@ -1,0 +1,65 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Param,
+  Body,
+  Headers,
+  Req,
+  Res,
+  HttpStatus,
+  UseGuards,
+} from '@nestjs/common';
+import { Request, Response } from 'express';
+import { Throttle, ThrottlerGuard } from '@nestjs/throttler';
+import { X402Service } from './x402.service';
+import { DepositRequestDto } from './dto/deposit-request.dto';
+import type { X402DepositResponse } from '@polypay/shared';
+
+function resourceUrlFromRequest(req: Request): string {
+  const host =
+    (req.headers['x-forwarded-host'] as string | undefined) ??
+    req.get('host') ??
+    'localhost';
+  const proto =
+    (req.headers['x-forwarded-proto'] as string | undefined) ??
+    req.protocol ??
+    'http';
+  return `${proto}://${host}${req.originalUrl}`;
+}
+
+@Controller('x402')
+@UseGuards(ThrottlerGuard)
+export class X402Controller {
+  constructor(private readonly x402Service: X402Service) {}
+
+  @Throttle({ default: { ttl: 60_000, limit: 60 } })
+  @Get('deposit/:multisigAddress')
+  async discovery(
+    @Param('multisigAddress') multisigAddress: string,
+    @Req() req: Request,
+    @Res() res: Response,
+  ): Promise<void> {
+    const body = await this.x402Service.buildDiscoveryResponse(
+      multisigAddress,
+      resourceUrlFromRequest(req),
+    );
+    res.status(HttpStatus.PAYMENT_REQUIRED).json(body);
+  }
+
+  @Throttle({ default: { ttl: 60_000, limit: 10 } })
+  @Post('deposit/:multisigAddress')
+  async deposit(
+    @Param('multisigAddress') multisigAddress: string,
+    @Headers('x-payment') paymentHeader: string | undefined,
+    @Body() body: DepositRequestDto,
+    @Req() req: Request,
+  ): Promise<X402DepositResponse> {
+    return this.x402Service.processDeposit(
+      multisigAddress,
+      paymentHeader,
+      body?.memo,
+      resourceUrlFromRequest(req),
+    );
+  }
+}

--- a/packages/backend/src/x402/x402.module.ts
+++ b/packages/backend/src/x402/x402.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { X402Controller } from './x402.controller';
+import { X402Service } from './x402.service';
+import { Eip712DomainCacheService } from './eip712-domain-cache.service';
+import { DatabaseModule } from '@/database/database.module';
+
+@Module({
+  imports: [DatabaseModule],
+  controllers: [X402Controller],
+  providers: [X402Service, Eip712DomainCacheService],
+})
+export class X402Module {}

--- a/packages/backend/src/x402/x402.service.ts
+++ b/packages/backend/src/x402/x402.service.ts
@@ -1,0 +1,384 @@
+import {
+  Injectable,
+  Logger,
+  BadRequestException,
+  NotFoundException,
+  InternalServerErrorException,
+  HttpException,
+  HttpStatus,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import axios, { AxiosError } from 'axios';
+import { createPublicClient, http } from 'viem';
+import {
+  USDC_TOKEN,
+  getChainById,
+  chainIdToFacilitatorNetwork,
+  isX402SupportedChain,
+} from '@polypay/shared';
+import type {
+  X402DepositResponse,
+  X402DiscoveryResponse,
+  X402PaymentRequirements,
+  X402V1PaymentPayload,
+} from '@polypay/shared';
+import { PrismaService } from '@/database/prisma.service';
+import { CONFIG_KEYS } from '@/config/config.keys';
+import { recoverEip3009Signer } from './utils/eip3009-validator';
+import { decodeXPaymentHeader } from './utils/x402-payment';
+import { Eip712DomainCacheService } from './eip712-domain-cache.service';
+import {
+  MIN_DEPOSIT,
+  MAX_DEPOSIT,
+  AUTH_BUFFER_SECONDS,
+  PER_MULTISIG_RATE_LIMIT_COUNT,
+  PER_MULTISIG_RATE_LIMIT_WINDOW_MS,
+} from './constants';
+
+const USDC_AUTHORIZATION_STATE_ABI = [
+  {
+    name: 'authorizationState',
+    type: 'function',
+    stateMutability: 'view',
+    inputs: [
+      { name: 'authorizer', type: 'address' },
+      { name: 'nonce', type: 'bytes32' },
+    ],
+    outputs: [{ name: '', type: 'bool' }],
+  },
+] as const;
+
+@Injectable()
+export class X402Service {
+  private readonly logger = new Logger(X402Service.name);
+
+  constructor(
+    private readonly config: ConfigService,
+    private readonly prisma: PrismaService,
+    private readonly domainCache: Eip712DomainCacheService,
+  ) {}
+
+  // ---------- public surface ----------
+
+  async buildDiscoveryResponse(
+    multisigAddress: string,
+    resourceUrl: string,
+  ): Promise<X402DiscoveryResponse> {
+    const account = await this.assertAccount(multisigAddress);
+    const requirements = this.buildPaymentRequirements(
+      account.chainId,
+      account.address,
+      resourceUrl,
+      MAX_DEPOSIT.toString(),
+    );
+    return { accepts: [requirements] };
+  }
+
+  async processDeposit(
+    multisigAddress: string,
+    paymentHeader: string | undefined,
+    memo: string | undefined,
+    resourceUrl: string,
+  ): Promise<X402DepositResponse> {
+    if (!paymentHeader) {
+      throw new BadRequestException('Missing X-PAYMENT header');
+    }
+    const account = await this.assertAccount(multisigAddress);
+    const payload = decodeXPaymentHeader(paymentHeader);
+
+    await this.validatePayloadAgainstMultisig(
+      payload,
+      account.address,
+      account.chainId,
+    );
+    await this.assertNonceUnused(
+      payload.payload.authorization.from,
+      payload.payload.authorization.nonce,
+      account.chainId,
+    );
+    await this.assertPerMultisigRateLimit(account.address);
+
+    const deposit = await this.prisma.x402Deposit.create({
+      data: {
+        buyerAddress: payload.payload.authorization.from.toLowerCase(),
+        multisigAddress: account.address.toLowerCase(),
+        principalAmount: payload.payload.authorization.value,
+        principalAuthNonce: payload.payload.authorization.nonce.toLowerCase(),
+        chainId: account.chainId,
+        memo,
+      },
+    });
+
+    // For verify/settle: maxAmountRequired must be <= auth.value (facilitator
+    // checks `auth.value >= maxAmountRequired`). Use the exact signed amount.
+    const requirements = this.buildPaymentRequirements(
+      account.chainId,
+      account.address,
+      resourceUrl,
+      payload.payload.authorization.value,
+    );
+
+    try {
+      await this.facilitatorVerify(payload, requirements);
+      const txHash = await this.facilitatorSettle(payload, requirements);
+      const updated = await this.prisma.x402Deposit.update({
+        where: { id: deposit.id },
+        data: { status: 'SETTLED', principalTxHash: txHash },
+      });
+      return {
+        principalTxHash: txHash,
+        multisigAddress: account.address,
+        depositedAmount: payload.payload.authorization.value,
+        chainId: account.chainId,
+        status: 'SETTLED',
+        timestamp: updated.updatedAt.toISOString(),
+      };
+    } catch (err) {
+      const message = this.shortenError(err);
+      this.logger.error(`Deposit ${deposit.id} failed: ${message}`);
+      await this.prisma.x402Deposit.update({
+        where: { id: deposit.id },
+        data: { status: 'FAILED', errorMessage: message },
+      });
+      if (err instanceof HttpException) throw err;
+      throw new InternalServerErrorException('Deposit settlement failed');
+    }
+  }
+
+  // ---------- validation helpers ----------
+
+  private async assertAccount(multisigAddress: string) {
+    if (!/^0x[a-fA-F0-9]{40}$/.test(multisigAddress)) {
+      throw new BadRequestException('Invalid address format');
+    }
+    const account = await this.prisma.account.findUnique({
+      where: { address: multisigAddress.toLowerCase() },
+    });
+    if (!account) {
+      throw new NotFoundException('Multisig not found');
+    }
+    if (!isX402SupportedChain(account.chainId)) {
+      throw new BadRequestException('Chain not supported by x402');
+    }
+    return account;
+  }
+
+  private async validatePayloadAgainstMultisig(
+    payload: X402V1PaymentPayload,
+    multisigAddress: string,
+    chainId: number,
+  ): Promise<void> {
+    const auth = payload.payload.authorization;
+    const network = chainIdToFacilitatorNetwork(chainId);
+
+    if (payload.network !== network) {
+      throw new BadRequestException('Network mismatch with multisig chain');
+    }
+    if (auth.to.toLowerCase() !== multisigAddress.toLowerCase()) {
+      throw new BadRequestException('Authorization "to" does not match path');
+    }
+    if (!/^0x[a-fA-F0-9]{40}$/.test(auth.from)) {
+      throw new BadRequestException('Invalid "from" address');
+    }
+
+    let value: bigint;
+    try {
+      value = BigInt(auth.value);
+    } catch {
+      throw new BadRequestException('Invalid "value"');
+    }
+    if (value < MIN_DEPOSIT || value > MAX_DEPOSIT) {
+      throw new BadRequestException('Amount out of bounds');
+    }
+
+    const now = Math.floor(Date.now() / 1000);
+    if (Number(auth.validBefore) <= now + AUTH_BUFFER_SECONDS) {
+      throw new BadRequestException('Authorization expires too soon');
+    }
+    if (Number(auth.validAfter) > now) {
+      throw new BadRequestException('Authorization not yet valid');
+    }
+
+    const sig = payload.payload.signature;
+    const r = '0x' + sig.slice(2, 66);
+    const s = '0x' + sig.slice(66, 130);
+    const v = parseInt(sig.slice(130, 132), 16);
+
+    const domain = this.domainCache.get(chainId);
+    const recovered = await recoverEip3009Signer(
+      {
+        from: auth.from,
+        to: auth.to,
+        value: auth.value,
+        validAfter: Number(auth.validAfter),
+        validBefore: Number(auth.validBefore),
+        nonce: auth.nonce,
+        v,
+        r,
+        s,
+      },
+      domain,
+    );
+    if (recovered.toLowerCase() !== auth.from.toLowerCase()) {
+      throw new BadRequestException('Invalid signature');
+    }
+  }
+
+  private async assertNonceUnused(
+    from: string,
+    nonce: string,
+    chainId: number,
+  ): Promise<void> {
+    const existing = await this.prisma.x402Deposit.findUnique({
+      where: { principalAuthNonce: nonce.toLowerCase() },
+    });
+    if (existing) {
+      throw new BadRequestException('Nonce already used');
+    }
+    const chain = getChainById(chainId);
+    const usdc = USDC_TOKEN.addresses[chainId] as `0x${string}`;
+    const client = createPublicClient({ chain, transport: http() });
+    const used = await client.readContract({
+      address: usdc,
+      abi: USDC_AUTHORIZATION_STATE_ABI,
+      functionName: 'authorizationState',
+      args: [from as `0x${string}`, nonce as `0x${string}`],
+    });
+    if (used) {
+      throw new BadRequestException('Authorization already consumed on-chain');
+    }
+  }
+
+  private async assertPerMultisigRateLimit(
+    multisigAddress: string,
+  ): Promise<void> {
+    const since = new Date(Date.now() - PER_MULTISIG_RATE_LIMIT_WINDOW_MS);
+    const count = await this.prisma.x402Deposit.count({
+      where: {
+        multisigAddress: multisigAddress.toLowerCase(),
+        createdAt: { gte: since },
+      },
+    });
+    if (count >= PER_MULTISIG_RATE_LIMIT_COUNT) {
+      throw new HttpException(
+        'Too many deposits to this multisig',
+        HttpStatus.TOO_MANY_REQUESTS,
+      );
+    }
+  }
+
+  // ---------- facilitator ----------
+
+  private buildPaymentRequirements(
+    chainId: number,
+    payTo: string,
+    resourceUrl: string,
+    maxAmountRequired: string,
+  ): X402PaymentRequirements {
+    const domain = this.domainCache.get(chainId);
+    return {
+      scheme: 'exact',
+      network: chainIdToFacilitatorNetwork(chainId),
+      asset: USDC_TOKEN.addresses[chainId],
+      payTo,
+      maxAmountRequired,
+      resource: resourceUrl,
+      description:
+        `Gasless USDC deposit to PolyPay multisig ${payTo}. Sign EIP-3009 ` +
+        `transferWithAuthorization for any amount in [${MIN_DEPOSIT}, ${MAX_DEPOSIT}] ` +
+        `(6-decimals USDC).`,
+      mimeType: 'application/json',
+      maxTimeoutSeconds: 120,
+      extra: {
+        // EIP-712 domain — facilitator requires these for "exact" scheme on EVM
+        // to verify the signature against the asset contract.
+        name: domain.name,
+        version: domain.version,
+        // Application-specific bounds (informational for clients).
+        minDeposit: MIN_DEPOSIT.toString(),
+        maxDeposit: MAX_DEPOSIT.toString(),
+      },
+    };
+  }
+
+  private facilitatorUrl(action: 'verify' | 'settle'): string {
+    const base = this.config
+      .get<string>(CONFIG_KEYS.X402_FACILITATOR_URL)
+      .replace(/\/$/, '');
+    if (base.includes('cdp.coinbase.com')) {
+      return base.endsWith('/v2/x402')
+        ? `${base}/${action}`
+        : `${base}/v2/x402/${action}`;
+    }
+    return `${base}/${action}`;
+  }
+
+  private facilitatorHeaders(): Record<string, string> {
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+    };
+    const token = this.config.get<string>(
+      CONFIG_KEYS.X402_FACILITATOR_BEARER_TOKEN,
+    );
+    if (token) headers.Authorization = `Bearer ${token}`;
+    return headers;
+  }
+
+  private async facilitatorVerify(
+    payload: X402V1PaymentPayload,
+    requirements: X402PaymentRequirements,
+  ): Promise<void> {
+    const resp = await axios.post(
+      this.facilitatorUrl('verify'),
+      {
+        x402Version: 1,
+        paymentPayload: payload,
+        paymentRequirements: requirements,
+      },
+      { headers: this.facilitatorHeaders(), validateStatus: () => true },
+    );
+    if (resp.status >= 400 || !this.isVerifyOk(resp.data)) {
+      throw new BadRequestException(
+        `Facilitator verify failed: ${JSON.stringify(resp.data ?? resp.status)}`,
+      );
+    }
+  }
+
+  private isVerifyOk(data: unknown): boolean {
+    if (typeof data !== 'object' || data === null) return false;
+    const d = data as Record<string, unknown>;
+    if (d.invalidReason || d.errorReason || d.errorMessage) return false;
+    return d.isValid === true || d.valid === true || d.success === true;
+  }
+
+  private async facilitatorSettle(
+    payload: X402V1PaymentPayload,
+    requirements: X402PaymentRequirements,
+  ): Promise<string> {
+    const resp = await axios.post(
+      this.facilitatorUrl('settle'),
+      {
+        x402Version: 1,
+        paymentPayload: payload,
+        paymentRequirements: requirements,
+      },
+      { headers: this.facilitatorHeaders(), validateStatus: () => true },
+    );
+    const data = resp.data as Record<string, unknown> | undefined;
+    if (!data?.success || typeof data.transaction !== 'string') {
+      throw new Error(
+        `Facilitator settle failed: ${
+          (data?.errorMessage as string | undefined) ??
+          JSON.stringify(data ?? resp.status)
+        }`,
+      );
+    }
+    return data.transaction;
+  }
+
+  private shortenError(err: unknown): string {
+    if (err instanceof AxiosError) return `axios: ${err.message}`;
+    if (err instanceof Error) return err.message.slice(0, 500);
+    return String(err).slice(0, 500);
+  }
+}

--- a/packages/nextjs/.env.example
+++ b/packages/nextjs/.env.example
@@ -1,2 +1,5 @@
 NEXT_PUBLIC_API_URL="http://localhost:4000"
 NEXT_PUBLIC_NETWORK="testnet"
+
+# x402 gasless USDC deposit (optional)
+NEXT_PUBLIC_FEATURE_X402_DEPOSIT=false

--- a/packages/nextjs/components/modals/DepositModal.tsx
+++ b/packages/nextjs/components/modals/DepositModal.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+import React from "react";
+import { isX402SupportedChain } from "@polypay/shared";
+import { parseUnits } from "viem";
+import { useChainId, useSwitchChain } from "wagmi";
+import { z } from "zod";
+import ModalContainer from "~~/components/modals/ModalContainer";
+import { useX402Deposit } from "~~/hooks/api/useX402Deposit";
+import { useZodForm } from "~~/hooks/form";
+import type { ModalProps } from "~~/types/modal";
+import { notification } from "~~/utils/scaffold-eth/notification";
+
+const schema = z.object({
+  amount: z.string().refine(v => {
+    const n = Number(v);
+    return Number.isFinite(n) && n >= 1 && n <= 10_000;
+  }, "Amount must be between 1 and 10,000 USDC"),
+});
+
+type FormValues = z.infer<typeof schema>;
+
+export interface DepositModalProps extends ModalProps {
+  multisigAddress?: `0x${string}`;
+  multisigChainId?: number;
+}
+
+function txExplorerUrl(chainId: number, txHash: string): string {
+  return chainId === 84532 ? `https://sepolia.basescan.org/tx/${txHash}` : `https://basescan.org/tx/${txHash}`;
+}
+
+const DepositModal: React.FC<DepositModalProps> = ({ isOpen, onClose, multisigAddress, multisigChainId }) => {
+  const chainId = useChainId();
+  const { switchChain } = useSwitchChain();
+  const { mutate, isPending, isSuccess, data, error, reset } = useX402Deposit();
+  const form = useZodForm({ schema, defaultValues: { amount: "" } });
+
+  const wrongChain = typeof multisigChainId === "number" && chainId !== multisigChainId;
+  const unsupported = !isX402SupportedChain(chainId);
+
+  const handleSubmit = form.handleSubmit((values: FormValues) => {
+    if (!multisigAddress) {
+      notification.error("Missing multisig address");
+      return;
+    }
+    mutate({
+      multisigAddress,
+      amount: parseUnits(values.amount, 6),
+    });
+  });
+
+  const handleClose = () => {
+    reset();
+    form.reset();
+    onClose();
+  };
+
+  return (
+    <ModalContainer
+      isOpen={isOpen}
+      onClose={handleClose}
+      title="Deposit USDC"
+      isCloseButton
+      className="bg-white rounded-3xl w-[min(480px,92vw)] px-5 py-5 shadow-modal"
+    >
+      {!isSuccess ? (
+        <form onSubmit={handleSubmit} className="flex flex-col gap-3 pt-3">
+          <p className="text-sm text-base-content/70 pr-10">
+            Deposit USDC to this multisig without paying gas. You will sign one message off-chain.
+          </p>
+
+          {wrongChain && (
+            <div className="flex flex-col gap-2 rounded border border-warning/50 bg-warning/10 p-3">
+              <span className="text-sm text-warning">Your wallet is on a different network than this multisig.</span>
+              <button
+                type="button"
+                className="btn btn-sm btn-warning"
+                onClick={() => multisigChainId && switchChain({ chainId: multisigChainId })}
+              >
+                Switch network
+              </button>
+            </div>
+          )}
+
+          {unsupported && <p className="text-error text-sm">Connect to Base or Base Sepolia to continue.</p>}
+
+          <label className="text-sm font-medium">Amount (USDC)</label>
+          <input
+            {...form.register("amount")}
+            type="text"
+            inputMode="decimal"
+            autoComplete="off"
+            placeholder="1"
+            disabled={isPending || wrongChain || unsupported}
+            className="w-full h-11 px-4 rounded-full border border-grey-300 bg-white text-base outline-none focus:border-grey-500 disabled:opacity-50"
+          />
+          {form.formState.errors.amount && (
+            <span className="text-error text-xs">{form.formState.errors.amount.message}</span>
+          )}
+          {error && <p className="text-error text-sm">{(error as Error).message}</p>}
+
+          <button type="submit" disabled={isPending || wrongChain || unsupported} className="btn btn-primary w-full">
+            {isPending ? "Signing / submitting…" : "Deposit"}
+          </button>
+        </form>
+      ) : (
+        <div className="flex flex-col gap-3 pt-3">
+          <p className="text-success font-medium">Deposit submitted</p>
+          <p className="text-sm">Status: {data?.status}</p>
+          {data?.principalTxHash && (
+            <a
+              href={txExplorerUrl(data.chainId, data.principalTxHash)}
+              target="_blank"
+              rel="noreferrer"
+              className="text-xs link link-primary break-all"
+            >
+              Tx: {data.principalTxHash}
+            </a>
+          )}
+          <button type="button" className="btn btn-ghost w-full" onClick={handleClose}>
+            Close
+          </button>
+        </div>
+      )}
+    </ModalContainer>
+  );
+};
+
+export default DepositModal;

--- a/packages/nextjs/components/modals/ModalLayout.tsx
+++ b/packages/nextjs/components/modals/ModalLayout.tsx
@@ -55,6 +55,7 @@ const modals: ModalRegistry = {
   claimReward: dynamic(() => import("./ClaimRewardModal"), { ssr: false }),
   questIntro: dynamic(() => import("./QuestIntroModal"), { ssr: false }),
   createBatchFromContacts: dynamic(() => import("./CreateBatchFromContactsModal"), { ssr: false }),
+  depositX402: dynamic(() => import("./DepositModal"), { ssr: false }),
 };
 
 type ModalInstance = {

--- a/packages/nextjs/components/modals/PortFolioModal.tsx
+++ b/packages/nextjs/components/modals/PortFolioModal.tsx
@@ -4,8 +4,8 @@ import React from "react";
 import Image from "next/image";
 import { Button } from "../ui/button";
 import { Sheet, SheetClose, SheetContent, SheetTitle, SheetTrigger } from "../ui/sheet";
-import { ResolvedToken } from "@polypay/shared";
-import { Eye, EyeOff, MoveDown, MoveUp, X } from "lucide-react";
+import { ResolvedToken, isX402SupportedChain } from "@polypay/shared";
+import { ArrowDownToLine, Eye, EyeOff, MoveDown, MoveUp, X } from "lucide-react";
 import { Address } from "viem";
 import NetworkBadge from "~~/components/Common/NetworkBadge";
 import { useMetaMultiSigWallet } from "~~/hooks";
@@ -141,24 +141,51 @@ export const PortfolioModal: React.FC<PortfolioModalProps> = ({ children }) => {
               </div>
 
               {/* Action Buttons */}
-              <div className="flex gap-1 p-1 bg-[rgba(0,0,0,0.47)] backdrop-blur-[15px] rounded-[15px]">
-                <SheetClose asChild>
-                  <Button
-                    className="flex-1 h-icon-btn px-6 py-2 bg-[rgba(248,248,248,0.13)] hover:bg-[rgba(248,248,248,0.25)] rounded-xl border border-[rgba(255,255,255,0.25)] cursor-pointer"
-                    onClick={() => router.goToTransfer()}
-                  >
-                    <MoveUp className="h-5 w-5 text-grey-50" />
-                    <span className="text-grey-50 text-base font-normal leading-[19px]">Transfer</span>
-                  </Button>
-                </SheetClose>
-                <Button
-                  className="flex-1 h-icon-btn px-6 py-2 bg-[rgba(248,248,248,0.13)] hover:bg-[rgba(248,248,248,0.25)] rounded-xl border border-[rgba(255,255,255,0.25)] cursor-pointer"
-                  onClick={() => openModal("qrAddressReceiver", { address: metaMultiSigWallet?.address as Address })}
-                >
-                  <MoveDown className="h-5 w-5 text-grey-50" />
-                  <span className="text-grey-50 text-base font-normal leading-[19px]">Receive</span>
-                </Button>
-              </div>
+              {(() => {
+                const showDeposit =
+                  process.env.NEXT_PUBLIC_FEATURE_X402_DEPOSIT === "true" && isX402SupportedChain(chainId);
+                const btnPad = showDeposit ? "px-2" : "px-6";
+                const txtSize = showDeposit ? "text-sm" : "text-base";
+                const iconSize = showDeposit ? "h-4 w-4" : "h-5 w-5";
+                const btnClass = `flex-1 min-w-0 h-icon-btn ${btnPad} py-2 gap-1 bg-[rgba(248,248,248,0.13)] hover:bg-[rgba(248,248,248,0.25)] rounded-xl border border-[rgba(255,255,255,0.25)] cursor-pointer`;
+                const labelClass = `text-grey-50 ${txtSize} font-normal leading-[19px]`;
+                const iconClass = `${iconSize} text-grey-50 shrink-0`;
+                return (
+                  <div className="flex gap-1 p-1 bg-[rgba(0,0,0,0.47)] backdrop-blur-[15px] rounded-[15px]">
+                    <SheetClose asChild>
+                      <Button className={btnClass} onClick={() => router.goToTransfer()}>
+                        <MoveUp className={iconClass} />
+                        <span className={labelClass}>Transfer</span>
+                      </Button>
+                    </SheetClose>
+                    <Button
+                      className={btnClass}
+                      onClick={() =>
+                        openModal("qrAddressReceiver", { address: metaMultiSigWallet?.address as Address })
+                      }
+                    >
+                      <MoveDown className={iconClass} />
+                      <span className={labelClass}>Receive</span>
+                    </Button>
+                    {showDeposit && (
+                      <SheetClose asChild>
+                        <Button
+                          className={btnClass}
+                          onClick={() =>
+                            openModal("depositX402", {
+                              multisigAddress: metaMultiSigWallet?.address as `0x${string}`,
+                              multisigChainId: chainId,
+                            })
+                          }
+                        >
+                          <ArrowDownToLine className={iconClass} />
+                          <span className={labelClass}>Deposit</span>
+                        </Button>
+                      </SheetClose>
+                    )}
+                  </div>
+                );
+              })()}
             </div>
           </div>
 

--- a/packages/nextjs/hooks/api/index.ts
+++ b/packages/nextjs/hooks/api/index.ts
@@ -7,3 +7,4 @@ export * from "./useNotification";
 export * from "./usePrice";
 export * from "./useQuest";
 export * from "./useClaim";
+export * from "./useX402Deposit";

--- a/packages/nextjs/hooks/api/useX402Deposit.ts
+++ b/packages/nextjs/hooks/api/useX402Deposit.ts
@@ -1,0 +1,73 @@
+import { accountKeys } from "./useAccount";
+import { USDC_TOKEN, chainIdToFacilitatorNetwork, isX402SupportedChain } from "@polypay/shared";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useAccount, useChainId, usePublicClient, useWalletClient } from "wagmi";
+import { encodeXPaymentHeader, x402Api } from "~~/services/api/x402Api";
+import { buildX402V1PaymentPayload, signEip3009Authorization } from "~~/utils/eip3009";
+import { notification } from "~~/utils/scaffold-eth/notification";
+
+const USDC_DOMAIN_ABI = [
+  { name: "name", type: "function", stateMutability: "view", inputs: [], outputs: [{ type: "string" }] },
+  { name: "version", type: "function", stateMutability: "view", inputs: [], outputs: [{ type: "string" }] },
+] as const;
+
+export function useX402Deposit() {
+  const { data: walletClient } = useWalletClient();
+  const publicClient = usePublicClient();
+  const { address } = useAccount();
+  const chainId = useChainId();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (params: { multisigAddress: `0x${string}`; amount: bigint }) => {
+      if (!walletClient || !address) {
+        throw new Error("Wallet not connected");
+      }
+      if (!publicClient) {
+        throw new Error("RPC client not ready");
+      }
+      if (!isX402SupportedChain(chainId)) {
+        throw new Error("Connect to Base or Base Sepolia to deposit via x402");
+      }
+
+      const usdc = USDC_TOKEN.addresses[chainId] as `0x${string}` | undefined;
+      if (!usdc) {
+        throw new Error(`USDC address missing for chain ${chainId}`);
+      }
+
+      const [domainName, domainVersion] = await Promise.all([
+        publicClient.readContract({ address: usdc, abi: USDC_DOMAIN_ABI, functionName: "name" }),
+        publicClient.readContract({ address: usdc, abi: USDC_DOMAIN_ABI, functionName: "version" }),
+      ]);
+
+      const network = chainIdToFacilitatorNetwork(chainId);
+      const addr = address as `0x${string}`;
+
+      const auth = await signEip3009Authorization({
+        walletClient,
+        account: addr,
+        usdcContract: usdc,
+        chainId,
+        from: addr,
+        to: params.multisigAddress,
+        value: params.amount,
+        domainName,
+        domainVersion,
+      });
+
+      const payload = buildX402V1PaymentPayload(network, auth);
+      const header = encodeXPaymentHeader(payload);
+
+      return x402Api.deposit(params.multisigAddress, header);
+    },
+    onSuccess: (_data, params) => {
+      notification.success("Deposit submitted");
+      void queryClient.invalidateQueries({
+        queryKey: accountKeys.byAddress(params.multisigAddress),
+      });
+    },
+    onError: (err: Error) => {
+      notification.error(err.message);
+    },
+  });
+}

--- a/packages/nextjs/services/api/index.ts
+++ b/packages/nextjs/services/api/index.ts
@@ -10,3 +10,4 @@ export { featureRequestApi } from "./featureRequestApi";
 export { queryClient } from "../queryClient";
 export { questApi } from "./questApi";
 export { claimApi } from "./claimApi";
+export { x402Api, encodeXPaymentHeader } from "./x402Api";

--- a/packages/nextjs/services/api/x402Api.ts
+++ b/packages/nextjs/services/api/x402Api.ts
@@ -1,0 +1,40 @@
+import {
+  API_ENDPOINTS,
+  type X402DepositRequest,
+  type X402DepositResponse,
+  type X402DiscoveryResponse,
+} from "@polypay/shared";
+import axios from "axios";
+import { API_BASE_URL } from "~~/constants";
+
+const x402Client = axios.create({
+  baseURL: API_BASE_URL,
+  headers: { "Content-Type": "application/json" },
+});
+
+export function encodeXPaymentHeader(payload: object): string {
+  return btoa(JSON.stringify(payload));
+}
+
+export const x402Api = {
+  discovery: async (multisigAddress: string): Promise<X402DiscoveryResponse> => {
+    const res = await x402Client.get(API_ENDPOINTS.x402.deposit(multisigAddress), {
+      validateStatus: status => status === 402,
+    });
+    if (res.status !== 402) {
+      throw new Error(`Expected HTTP 402 from discovery, got ${res.status}`);
+    }
+    return res.data as X402DiscoveryResponse;
+  },
+
+  deposit: async (
+    multisigAddress: string,
+    xPaymentBase64: string,
+    body: X402DepositRequest = {},
+  ): Promise<X402DepositResponse> => {
+    const { data } = await x402Client.post<X402DepositResponse>(API_ENDPOINTS.x402.deposit(multisigAddress), body, {
+      headers: { "X-PAYMENT": xPaymentBase64 },
+    });
+    return data;
+  },
+};

--- a/packages/nextjs/types/modal.ts
+++ b/packages/nextjs/types/modal.ts
@@ -31,4 +31,5 @@ export type ModalName =
   | "disclaimer"
   | "claimReward"
   | "questIntro"
-  | "createBatchFromContacts";
+  | "createBatchFromContacts"
+  | "depositX402";

--- a/packages/nextjs/utils/eip3009.ts
+++ b/packages/nextjs/utils/eip3009.ts
@@ -1,0 +1,100 @@
+import type { Eip3009Authorization, X402V1PaymentPayload } from "@polypay/shared";
+import type { WalletClient } from "viem";
+import { parseSignature } from "viem";
+
+const TRANSFER_WITH_AUTHORIZATION_TYPES = {
+  TransferWithAuthorization: [
+    { name: "from", type: "address" },
+    { name: "to", type: "address" },
+    { name: "value", type: "uint256" },
+    { name: "validAfter", type: "uint256" },
+    { name: "validBefore", type: "uint256" },
+    { name: "nonce", type: "bytes32" },
+  ],
+} as const;
+
+export async function signEip3009Authorization(params: {
+  walletClient: WalletClient;
+  account: `0x${string}`;
+  usdcContract: `0x${string}`;
+  chainId: number;
+  from: `0x${string}`;
+  to: `0x${string}`;
+  value: bigint;
+  validitySeconds?: number;
+  /** EIP-712 domain `name` of the USDC contract (e.g. "USD Coin" mainnet, "USDC" Sepolia). */
+  domainName: string;
+  /** EIP-712 domain `version` of the USDC contract (usually "2"). */
+  domainVersion: string;
+}): Promise<Eip3009Authorization> {
+  const validitySeconds = params.validitySeconds ?? 300;
+  const now = Math.floor(Date.now() / 1000);
+  const validAfter = 0;
+  const validBefore = now + validitySeconds;
+  const nonce = randomBytes32();
+
+  const sig = await params.walletClient.signTypedData({
+    account: params.account,
+    domain: {
+      name: params.domainName,
+      version: params.domainVersion,
+      chainId: params.chainId,
+      verifyingContract: params.usdcContract,
+    },
+    types: TRANSFER_WITH_AUTHORIZATION_TYPES,
+    primaryType: "TransferWithAuthorization",
+    message: {
+      from: params.from,
+      to: params.to,
+      value: params.value,
+      validAfter: BigInt(validAfter),
+      validBefore: BigInt(validBefore),
+      nonce,
+    },
+  });
+
+  const { v, r, s } = parseSignature(sig);
+
+  return {
+    from: params.from,
+    to: params.to,
+    value: params.value.toString(),
+    validAfter,
+    validBefore,
+    nonce,
+    v: Number(v),
+    r,
+    s,
+  };
+}
+
+/** Build x402 v1 `X-PAYMENT` JSON (base64-encode before sending). */
+export function buildX402V1PaymentPayload(
+  facilitatorNetwork: string,
+  auth: Eip3009Authorization,
+): X402V1PaymentPayload {
+  const vHex = auth.v.toString(16).padStart(2, "0");
+  const signature = `0x${auth.r.slice(2)}${auth.s.slice(2)}${vHex}` as `0x${string}`;
+  return {
+    x402Version: 1,
+    scheme: "exact",
+    network: facilitatorNetwork,
+    payload: {
+      signature,
+      authorization: {
+        from: auth.from,
+        to: auth.to,
+        value: auth.value,
+        validAfter: String(auth.validAfter),
+        validBefore: String(auth.validBefore),
+        nonce: auth.nonce,
+      },
+    },
+  };
+}
+
+function randomBytes32(): `0x${string}` {
+  const bytes = new Uint8Array(32);
+  crypto.getRandomValues(bytes);
+  return `0x${[...bytes].map(b => b.toString(16).padStart(2, "0")).join("")}` as `0x${string}`;
+}

--- a/packages/shared/src/api/endpoints.ts
+++ b/packages/shared/src/api/endpoints.ts
@@ -86,4 +86,10 @@ export const API_ENDPOINTS = {
     base: "/api/claims",
     summary: "/api/claims/summary",
   },
+
+  x402: {
+    /** Build the path-based endpoint for a specific multisig. */
+    deposit: (multisigAddress: string): string =>
+      `/api/x402/deposit/${multisigAddress}`,
+  },
 } as const;

--- a/packages/shared/src/chains/facilitator-network.ts
+++ b/packages/shared/src/chains/facilitator-network.ts
@@ -1,0 +1,31 @@
+import { baseMainnet } from "./baseMainnet";
+import { baseSepolia } from "./baseSepolia";
+
+/**
+ * Map a chainId to the label the x402 facilitator expects in its payment
+ * payload and requirements. Throws for unsupported chains so callers never
+ * silently send a mainnet payment to a testnet facilitator.
+ */
+export function chainIdToFacilitatorNetwork(
+  chainId: number,
+): "base" | "base-sepolia" {
+  switch (chainId) {
+    case baseMainnet.id:
+      return "base";
+    case baseSepolia.id:
+      return "base-sepolia";
+    default:
+      throw new Error(
+        `Chain ${chainId} is not supported by the x402 facilitator`,
+      );
+  }
+}
+
+export const X402_SUPPORTED_CHAIN_IDS: readonly number[] = [
+  baseMainnet.id,
+  baseSepolia.id,
+];
+
+export function isX402SupportedChain(chainId: number): boolean {
+  return X402_SUPPORTED_CHAIN_IDS.includes(chainId);
+}

--- a/packages/shared/src/chains/index.ts
+++ b/packages/shared/src/chains/index.ts
@@ -16,6 +16,8 @@ export const getChain = (network: NetworkType) => {
   return network === NetworkValue.mainnet ? horizenMainnet : horizenTestnet;
 };
 
+export * from "./facilitator-network";
+
 // New helper: resolve chain by EVM chainId for multi-chain features.
 export const getChainById = (chainId: number) => {
   switch (chainId) {

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -10,3 +10,4 @@ export * from "./auth";
 export * from "./feature-request";
 export * from "./quest";
 export * from "./reward";
+export * from "./x402";

--- a/packages/shared/src/types/x402.ts
+++ b/packages/shared/src/types/x402.ts
@@ -1,0 +1,62 @@
+/** EIP-3009 TransferWithAuthorization fields + split ECDSA (wallet signing UX). */
+export interface Eip3009Authorization {
+  from: string;
+  to: string;
+  value: string;
+  validAfter: number;
+  validBefore: number;
+  nonce: string;
+  v: number;
+  r: string;
+  s: string;
+}
+
+/** x402 v1 payment payload (decoded from X-PAYMENT base64 JSON). */
+export interface X402V1PaymentPayload {
+  x402Version: 1;
+  scheme: "exact";
+  network: string;
+  payload: {
+    signature: string;
+    authorization: {
+      from: string;
+      to: string;
+      value: string;
+      validAfter: string;
+      validBefore: string;
+      nonce: string;
+    };
+  };
+}
+
+/** POST body. Path param carries multisigAddress; body is optional metadata. */
+export interface X402DepositRequest {
+  memo?: string;
+}
+
+export interface X402DepositResponse {
+  principalTxHash: string;
+  multisigAddress: string;
+  depositedAmount: string;
+  chainId: number;
+  status: "SETTLED" | "FAILED";
+  timestamp: string;
+}
+
+/** Coinbase / x402 v1 payment requirement item inside 402 `accepts`. */
+export interface X402PaymentRequirements {
+  scheme: "exact";
+  network: string;
+  asset: string;
+  payTo: string;
+  maxAmountRequired: string;
+  resource: string;
+  description: string;
+  mimeType: string;
+  maxTimeoutSeconds: number;
+  extra?: Record<string, unknown>;
+}
+
+export interface X402DiscoveryResponse {
+  accepts: X402PaymentRequirements[];
+}


### PR DESCRIPTION
Add gasless USDC deposit on Base (#238)

## Types of change
- [X] Feature
- [ ] Bug
- [ ] Enhancement

## Comments

  PolyPay users can now top up a multisig with USDC on Base in a single click — no
  ETH or gas needed. The deposit also works for AI agents and external apps that
  speak the x402 standard, so anyone (or any bot) can fund a PolyPay treasury just
  by knowing its address.

  **How to test:**
  1. Open the PolyPay app and switch your wallet to **Base** (mainnet or Sepolia).
  2. Make sure you have at least **1 USDC** in your wallet.
  3. Pick a Base multisig, then click the **Portfolio** button (top-right).
  4. Click **Deposit**, enter an amount (1–10,000 USDC), sign once in your wallet.
  5. The success screen shows a Basescan link. The USDC lands in the multisig
  within seconds.

**UI Screen**
<img width="272" height="168" alt="image" src="https://github.com/user-attachments/assets/2f599773-66c7-4f3c-b116-631617e88e81" />
<img width="430" height="211" alt="image" src="https://github.com/user-attachments/assets/6e86fc81-1351-405c-95a7-a2331fa84c88" />


  **How an agent can use it:**
  An AI agent (or any third-party script) can fund a PolyPay multisig autonomously,
   with no PolyPay account needed. The agent just needs the multisig address and a
  wallet with USDC. It calls our public deposit URL using any standard x402 client
  library — same flow, just done programmatically instead of through the app. This
  is what enables the "AI agent treasurer" use case: a bot that monitors a treasury
   and tops it up automatically when balance runs low.