### PR TITLE
ci: add Discord notifications alongside Slack in deploy workflows

### DIFF
--- a/.github/workflows/backend-prod.yaml
+++ b/.github/workflows/backend-prod.yaml
@@ -79,8 +79,10 @@ jobs:
             --allow-unauthenticated \
             --update-env-vars NETWORK=${{ vars.NETWORK }}
 
+      # --- Slack notifications ---
       - name: Notify Success to Slack Channel
         if: success()
+        continue-on-error: true
         uses: slackapi/slack-github-action@v1.26.0
         with:
           channel-id: ${{ secrets.SLACK_CHANNEL_ID }}
@@ -90,9 +92,49 @@ jobs:
 
       - name: Notify Failure to Slack Channel
         if: failure()
+        continue-on-error: true
         uses: slackapi/slack-github-action@v1.26.0
         with:
           channel-id: ${{ secrets.SLACK_CHANNEL_ID }}
           slack-message: "❌ Backend Deployment Failed!\nRepository: polypay-backend\nBranch: ${{ github.ref_name }}\nEnvironment: prod\nBuild Status: ${{ job.status }}\nTriggered by: ${{ github.actor }}\n${{ github.event.head_commit.url }}"
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+
+      # --- Discord notifications ---
+      - name: Notify Discord (Success)
+        if: success()
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+        run: |
+          if [ -z "$DISCORD_WEBHOOK_URL" ]; then echo "no Discord webhook configured"; exit 0; fi
+          payload=$(jq -n \
+            --arg branch "${{ github.ref_name }}" \
+            --arg actor "${{ github.actor }}" \
+            --arg url "${{ github.event.head_commit.url }}" \
+            '{content: (":white_check_mark: Backend Deployment Successful!\n"
+              + "Repository: polypay-backend\n"
+              + "Branch: " + $branch + "\n"
+              + "Environment: prod\n"
+              + "Build Status: success\n"
+              + "Triggered by: " + $actor + "\n"
+              + $url)}')
+          curl -sf -H "Content-Type: application/json" -X POST -d "$payload" "$DISCORD_WEBHOOK_URL"
+
+      - name: Notify Discord (Failure)
+        if: failure()
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+        run: |
+          if [ -z "$DISCORD_WEBHOOK_URL" ]; then echo "no Discord webhook configured"; exit 0; fi
+          payload=$(jq -n \
+            --arg branch "${{ github.ref_name }}" \
+            --arg actor "${{ github.actor }}" \
+            --arg url "${{ github.event.head_commit.url }}" \
+            '{content: (":x: Backend Deployment Failed!\n"
+              + "Repository: polypay-backend\n"
+              + "Branch: " + $branch + "\n"
+              + "Environment: prod\n"
+              + "Build Status: failure\n"
+              + "Triggered by: " + $actor + "\n"
+              + $url)}')
+          curl -sf -H "Content-Type: application/json" -X POST -d "$payload" "$DISCORD_WEBHOOK_URL"

--- a/.github/workflows/backend-staging.yaml
+++ b/.github/workflows/backend-staging.yaml
@@ -78,8 +78,10 @@ jobs:
             --allow-unauthenticated \
             --update-env-vars NETWORK=${{ vars.NETWORK }}
 
+      # --- Slack notifications ---
       - name: Notify Success to Slack Channel
         if: success()
+        continue-on-error: true
         uses: slackapi/slack-github-action@v1.26.0
         with:
           channel-id: ${{ secrets.SLACK_CHANNEL_ID }}
@@ -89,9 +91,49 @@ jobs:
 
       - name: Notify Failure to Slack Channel
         if: failure()
+        continue-on-error: true
         uses: slackapi/slack-github-action@v1.26.0
         with:
           channel-id: ${{ secrets.SLACK_CHANNEL_ID }}
           slack-message: "❌ [STAGING] Backend Deployment Failed!\nRepository: polypay-backend\nBranch: ${{ github.ref_name }}\nEnvironment: staging\nBuild Status: ${{ job.status }}\nTriggered by: ${{ github.actor }}\n${{ github.event.head_commit.url }}"
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+
+      # --- Discord notifications ---
+      - name: Notify Discord (Success)
+        if: success()
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+        run: |
+          if [ -z "$DISCORD_WEBHOOK_URL" ]; then echo "no Discord webhook configured"; exit 0; fi
+          payload=$(jq -n \
+            --arg branch "${{ github.ref_name }}" \
+            --arg actor "${{ github.actor }}" \
+            --arg url "${{ github.event.head_commit.url }}" \
+            '{content: (":white_check_mark: [STAGING] Backend Deployment Successful!\n"
+              + "Repository: polypay-backend\n"
+              + "Branch: " + $branch + "\n"
+              + "Environment: staging\n"
+              + "Build Status: success\n"
+              + "Triggered by: " + $actor + "\n"
+              + $url)}')
+          curl -sf -H "Content-Type: application/json" -X POST -d "$payload" "$DISCORD_WEBHOOK_URL"
+
+      - name: Notify Discord (Failure)
+        if: failure()
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+        run: |
+          if [ -z "$DISCORD_WEBHOOK_URL" ]; then echo "no Discord webhook configured"; exit 0; fi
+          payload=$(jq -n \
+            --arg branch "${{ github.ref_name }}" \
+            --arg actor "${{ github.actor }}" \
+            --arg url "${{ github.event.head_commit.url }}" \
+            '{content: (":x: [STAGING] Backend Deployment Failed!\n"
+              + "Repository: polypay-backend\n"
+              + "Branch: " + $branch + "\n"
+              + "Environment: staging\n"
+              + "Build Status: failure\n"
+              + "Triggered by: " + $actor + "\n"
+              + $url)}')
+          curl -sf -H "Content-Type: application/json" -X POST -d "$payload" "$DISCORD_WEBHOOK_URL"

--- a/.github/workflows/frontend-prod.yaml
+++ b/.github/workflows/frontend-prod.yaml
@@ -66,8 +66,10 @@ jobs:
             --platform managed \
             --allow-unauthenticated
 
+      # --- Slack notifications ---
       - name: Notify Success to Slack Channel
         if: success()
+        continue-on-error: true
         uses: slackapi/slack-github-action@v1.26.0
         with:
           channel-id: ${{ secrets.SLACK_CHANNEL_ID }}
@@ -77,9 +79,49 @@ jobs:
 
       - name: Notify Failure to Slack Channel
         if: failure()
+        continue-on-error: true
         uses: slackapi/slack-github-action@v1.26.0
         with:
           channel-id: ${{ secrets.SLACK_CHANNEL_ID }}
           slack-message: "❌ Frontend Deployment Failed!\nRepository: polypay-frontend\nBranch: ${{ github.ref_name }}\nEnvironment: prod\nBuild Status: ${{ job.status }}\nTriggered by: ${{ github.actor }}\n${{ github.event.head_commit.url }}"
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+
+      # --- Discord notifications ---
+      - name: Notify Discord (Success)
+        if: success()
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+        run: |
+          if [ -z "$DISCORD_WEBHOOK_URL" ]; then echo "no Discord webhook configured"; exit 0; fi
+          payload=$(jq -n \
+            --arg branch "${{ github.ref_name }}" \
+            --arg actor "${{ github.actor }}" \
+            --arg url "${{ github.event.head_commit.url }}" \
+            '{content: (":white_check_mark: Frontend Deployment Successful!\n"
+              + "Repository: polypay-frontend\n"
+              + "Branch: " + $branch + "\n"
+              + "Environment: prod\n"
+              + "Build Status: success\n"
+              + "Triggered by: " + $actor + "\n"
+              + $url)}')
+          curl -sf -H "Content-Type: application/json" -X POST -d "$payload" "$DISCORD_WEBHOOK_URL"
+
+      - name: Notify Discord (Failure)
+        if: failure()
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+        run: |
+          if [ -z "$DISCORD_WEBHOOK_URL" ]; then echo "no Discord webhook configured"; exit 0; fi
+          payload=$(jq -n \
+            --arg branch "${{ github.ref_name }}" \
+            --arg actor "${{ github.actor }}" \
+            --arg url "${{ github.event.head_commit.url }}" \
+            '{content: (":x: Frontend Deployment Failed!\n"
+              + "Repository: polypay-frontend\n"
+              + "Branch: " + $branch + "\n"
+              + "Environment: prod\n"
+              + "Build Status: failure\n"
+              + "Triggered by: " + $actor + "\n"
+              + $url)}')
+          curl -sf -H "Content-Type: application/json" -X POST -d "$payload" "$DISCORD_WEBHOOK_URL"

--- a/.github/workflows/frontend-staging.yaml
+++ b/.github/workflows/frontend-staging.yaml
@@ -65,8 +65,10 @@ jobs:
             --platform managed \
             --allow-unauthenticated
 
+      # --- Slack notifications ---
       - name: Notify Success to Slack Channel
         if: success()
+        continue-on-error: true
         uses: slackapi/slack-github-action@v1.26.0
         with:
           channel-id: ${{ secrets.SLACK_CHANNEL_ID }}
@@ -76,9 +78,49 @@ jobs:
 
       - name: Notify Failure to Slack Channel
         if: failure()
+        continue-on-error: true
         uses: slackapi/slack-github-action@v1.26.0
         with:
           channel-id: ${{ secrets.SLACK_CHANNEL_ID }}
           slack-message: "❌ [STAGING] Frontend Deployment Failed!\nRepository: polypay-frontend\nBranch: ${{ github.ref_name }}\nEnvironment: staging\nBuild Status: ${{ job.status }}\nTriggered by: ${{ github.actor }}\n${{ github.event.head_commit.url }}"
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+
+      # --- Discord notifications ---
+      - name: Notify Discord (Success)
+        if: success()
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+        run: |
+          if [ -z "$DISCORD_WEBHOOK_URL" ]; then echo "no Discord webhook configured"; exit 0; fi
+          payload=$(jq -n \
+            --arg branch "${{ github.ref_name }}" \
+            --arg actor "${{ github.actor }}" \
+            --arg url "${{ github.event.head_commit.url }}" \
+            '{content: (":white_check_mark: [STAGING] Frontend Deployment Successful!\n"
+              + "Repository: polypay-frontend\n"
+              + "Branch: " + $branch + "\n"
+              + "Environment: staging\n"
+              + "Build Status: success\n"
+              + "Triggered by: " + $actor + "\n"
+              + $url)}')
+          curl -sf -H "Content-Type: application/json" -X POST -d "$payload" "$DISCORD_WEBHOOK_URL"
+
+      - name: Notify Discord (Failure)
+        if: failure()
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+        run: |
+          if [ -z "$DISCORD_WEBHOOK_URL" ]; then echo "no Discord webhook configured"; exit 0; fi
+          payload=$(jq -n \
+            --arg branch "${{ github.ref_name }}" \
+            --arg actor "${{ github.actor }}" \
+            --arg url "${{ github.event.head_commit.url }}" \
+            '{content: (":x: [STAGING] Frontend Deployment Failed!\n"
+              + "Repository: polypay-frontend\n"
+              + "Branch: " + $branch + "\n"
+              + "Environment: staging\n"
+              + "Build Status: failure\n"
+              + "Triggered by: " + $actor + "\n"
+              + $url)}')
+          curl -sf -H "Content-Type: application/json" -X POST -d "$payload" "$DISCORD_WEBHOOK_URL"


### PR DESCRIPTION
## Summary

Mirrors the Q3Labs org-wide dual-notification pattern ([devops PR #27](https://github.com/Quantum3-Labs/devops/pull/27), [brove PR #404](https://github.com/Just-Brove-It/brove/pull/404)) in this repo. Wherever a workflow already had `Notify Success` / `Notify Failure` to Slack, a matching Discord step is added that POSTs the same body content to a webhook.

Slack steps are kept (so nothing breaks today) but marked `continue-on-error: true` — once Discord is the primary channel, missing/expired Slack secrets won't fail the workflow.

## Files changed

| Workflow | Environment | What was added |
|---|---|---|
| `.github/workflows/backend-prod.yaml` | prod | Discord success + failure |
| `.github/workflows/backend-staging.yaml` | staging | Discord success + failure |
| `.github/workflows/frontend-prod.yaml` | prod | Discord success + failure |
| `.github/workflows/frontend-staging.yaml` | staging | Discord success + failure |

## Discord step pattern

Plain-text content (not embeds), built with `jq -n --arg`, sent via `curl -sf -X POST` to the webhook. Each step:

- Reads `DISCORD_WEBHOOK_URL` from a secret env.
- If the secret is missing → prints `no Discord webhook configured` and `exit 0` (workflow still passes).
- Otherwise → posts a message with the same emoji/lines/labels as the existing Slack message (shortcodes `:white_check_mark:` / `:x:` to match Discord rendering). Staging workflows preserve the `[STAGING]` prefix.

## New secret required

- `DISCORD_WEBHOOK_URL` — add to the `Poly-pay/polypay_app` repo (or the appropriate deployment environment used by these workflows). Until it is set, every Discord notify step short-circuits, so this PR is safe to merge before the webhook is provisioned.

## Test plan

- [ ] Add `DISCORD_WEBHOOK_URL` secret to the repo (or deployment environment).
- [ ] Trigger backend-staging via a no-op push on the staging branch; verify Discord receives a success message and Slack still receives its message.
- [ ] Force a failure and verify both Discord and Slack receive the failure message.
- [ ] Repeat smoke test for backend-prod, frontend-prod, frontend-staging.
- [ ] Temporarily revoke the Slack token and confirm the workflow still passes (Slack step turns yellow via `continue-on-error`, Discord step succeeds).