### PR TITLE
fix(backend): bump cross-chain finalization wait to 2 minutes

### DIFF
--- a/packages/backend/src/common/constants/timing.ts
+++ b/packages/backend/src/common/constants/timing.ts
@@ -11,7 +11,7 @@ export const ZEN_TRANSFER_RETRY_DELAY = 2_000; // 2s
 export const PRICE_CAPTURE_RETRY_DELAY = 5_000; // 5s
 export const ZK_POLLING_DELAY = 5_000; // 5s
 export const PROOF_AGGREGATION_INTERVAL = 10_000; // 10s
-export const CROSS_CHAIN_FINALIZATION_WAIT = 40_000; // 40s
+export const CROSS_CHAIN_FINALIZATION_WAIT = 120_000; // 2min
 
 // Retry limits
 export const ZK_API_MAX_RETRIES = 3;

--- a/packages/backend/src/transaction/transaction-executor.service.ts
+++ b/packages/backend/src/transaction/transaction-executor.service.ts
@@ -596,7 +596,7 @@ export class TransactionExecutorService {
 
     if (hasRecentAggregation) {
       this.logger.log(
-        'Recent aggregation detected, waiting 40s for cross-chain finalization...',
+        `Recent aggregation detected, waiting ${CROSS_CHAIN_FINALIZATION_WAIT / 1000}s for cross-chain finalization...`,
       );
       await this.sleep(CROSS_CHAIN_FINALIZATION_WAIT);
     } else {


### PR DESCRIPTION
## What
Raises `CROSS_CHAIN_FINALIZATION_WAIT` from **40s → 120s (2 min)**, applied uniformly to all chains (Base, Horizen, Arbitrum Sepolia).

## Why
The zkVerify team confirmed proof **aggregation now completes within ~2 minutes** across supported networks, including **Arbitrum Sepolia** (previously slower). The executor waits this duration after a recent aggregation before polling for the cross-chain receipt; 40s was too short for the aggregation-to-finalization window, risking premature/stuck executions. 2 minutes matches the observed aggregation time.

> "both issues should have been addressed: arbitrum sepolia aggregation time is down to 2 minutes, and support for Arbitrum One Mainnet has been finalized" — zkVerify team

## Changes
- `packages/backend/src/common/constants/timing.ts` — `CROSS_CHAIN_FINALIZATION_WAIT` `40_000` → `120_000`.
- `packages/backend/src/transaction/transaction-executor.service.ts` — log message now derives the duration from the constant (`${CROSS_CHAIN_FINALIZATION_WAIT / 1000}s`) instead of a hardcoded "40s", so it can't drift.

## Notes
- This is a **single global constant** — there's no per-chain wait today, so Base/Horizen also move from 40s to 2 min. Per the decision to keep one uniform value.
- Overlaps with the same constant bump inside PR #282 (Arbitrum support); landing it standalone here decouples the timing fix from that larger PR. If #282 merges first this becomes a no-op; if this merges first, #282's diff for this line drops out.

## Validation
- No `node_modules` in this checkout, so local `tsc`/build not run. Change is a constant value + a log-string interpolation; CI `yarn build` (lint.yaml) will compile-check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)