### PR TITLE
chore(backend): stop weekly ZEN price cron (quest/reward disabled)

### DIFF
--- a/packages/backend/src/price/price.module.ts
+++ b/packages/backend/src/price/price.module.ts
@@ -4,7 +4,10 @@ import { CacheModule } from '@nestjs/cache-manager';
 import axiosRetry from 'axios-retry';
 import { PriceController } from './price.controller';
 import { PriceService } from './price.service';
-import { PriceScheduler } from './price.scheduler';
+// Weekly ZEN price capture only fed the Quest/Reward payout flow, which is
+// disabled. Keep price.scheduler.ts for future reuse but leave it unregistered
+// so its Friday cron stops running. Re-add PriceScheduler below to re-enable.
+// import { PriceScheduler } from './price.scheduler';
 import {
   HTTP_TIMEOUT_PRICE,
   PRICE_CACHE_TTL,
@@ -22,7 +25,7 @@ import {
     }),
   ],
   controllers: [PriceController],
-  providers: [PriceService, PriceScheduler],
+  providers: [PriceService],
   exports: [PriceService],
 })
 export class PriceModule {


### PR DESCRIPTION
## What
Unregister `PriceScheduler` from `PriceModule` so the weekly ZEN price capture cron (`0 11 * * 5`, Fridays) no longer runs.

## Why
The scheduler captured the weekly ZEN price solely to feed the Quest/Reward payout flow, which is disabled. With no consumer, the Friday cron kept hitting CoinGecko and writing `WeeklyZenPrice` rows for nothing.

## Kept for reuse (disable, not remove)
- `price.scheduler.ts` file and `PriceService` capture methods (`captureWeeklyZenPrice`, `getZenPriceForWeek`) left in place — re-add `PriceScheduler` to providers to re-enable.
- Live `GET /prices` endpoint unaffected.
- No Prisma schema changes.

## Test
- Backend build passes via pre-commit `yarn build:backend`.