### PR TITLE
feat(arbitrum): wire Arbitrum One (42161) mainnet support

### DIFF
--- a/packages/backend/src/common/constants/campaign.ts
+++ b/packages/backend/src/common/constants/campaign.ts
@@ -15,8 +15,8 @@ export const QUEST_POINTS_ACCOUNT_FIRST_TX = 100;
 export const QUEST_POINTS_SUCCESSFUL_TX = 50;
 
 // Supported chain IDs
-// 421614 = Arbitrum Sepolia (testnet only; account contract is the Stylus port).
-export const SUPPORTED_CHAIN_IDS = [2651420, 84532, 26514, 8453, 421614];
+// 421614 = Arbitrum Sepolia, 42161 = Arbitrum One (account contract is the Stylus port).
+export const SUPPORTED_CHAIN_IDS = [2651420, 84532, 26514, 8453, 421614, 42161];
 
 // External APIs
 export const COINGECKO_API_URL =

--- a/packages/backend/src/common/constants/proof.ts
+++ b/packages/backend/src/common/constants/proof.ts
@@ -4,4 +4,5 @@ export const DOMAIN_ID_BY_CHAIN_ID = {
   421614: 4, // Arbitrum Sepolia (zkVerify testnet domain)
   26514: 3, // Horizen mainnet
   8453: 2, // Base mainnet
+  42161: 10, // Arbitrum One (zkVerify System Domain, verified docs.zkverify.io)
 } as const;

--- a/packages/hardhat/hardhat.config.ts
+++ b/packages/hardhat/hardhat.config.ts
@@ -62,7 +62,8 @@ const config: HardhatUserConfig = {
       accounts: [deployerPrivateKey],
     },
     arbitrum: {
-      url: `https://arb-mainnet.g.alchemy.com/v2/${providerApiKey}`,
+      // Default Alchemy key is IP-whitelisted; use the public RPC unless overridden.
+      url: process.env.ARBITRUM_RPC || "https://arb1.arbitrum.io/rpc",
       accounts: [deployerPrivateKey],
     },
     arbitrumSepolia: {

--- a/packages/nextjs/components/NewAccount/ChooseNetwork.tsx
+++ b/packages/nextjs/components/NewAccount/ChooseNetwork.tsx
@@ -2,6 +2,7 @@
 
 import React from "react";
 import Image from "next/image";
+import { CHAIN_IDS } from "@polypay/shared";
 import { getDefaultChainId, getNetworkMeta } from "~~/utils/network";
 import { notification } from "~~/utils/scaffold-eth";
 
@@ -14,10 +15,7 @@ interface ChooseNetworkProps {
   isWalletConnected: boolean;
 }
 
-const HORIZEN_MAINNET = 26514;
-const BASE_MAINNET = 8453;
-// Arbitrum is testnet-only (zkVerify has no Arbitrum One mainnet verifier yet).
-const ARBITRUM_SEPOLIA = 421614;
+const { HORIZEN_MAINNET, HORIZEN_TESTNET, BASE_MAINNET, BASE_SEPOLIA, ARBITRUM_ONE, ARBITRUM_SEPOLIA } = CHAIN_IDS;
 
 const ChooseNetwork: React.FC<ChooseNetworkProps> = ({
   className,
@@ -29,13 +27,12 @@ const ChooseNetwork: React.FC<ChooseNetworkProps> = ({
 }) => {
   const defaultChainId = getDefaultChainId();
 
-  const isTestnet = defaultChainId === 2651420;
+  const isTestnet = defaultChainId === HORIZEN_TESTNET;
 
   const networks = [
-    { chainId: HORIZEN_MAINNET, fallbackChainId: 2651420 },
-    { chainId: BASE_MAINNET, fallbackChainId: 84532 },
-    // Arbitrum has no mainnet entry; only surfaced on testnet.
-    ...(isTestnet ? [{ chainId: ARBITRUM_SEPOLIA, fallbackChainId: ARBITRUM_SEPOLIA }] : []),
+    { chainId: HORIZEN_MAINNET, fallbackChainId: HORIZEN_TESTNET },
+    { chainId: BASE_MAINNET, fallbackChainId: BASE_SEPOLIA },
+    { chainId: ARBITRUM_ONE, fallbackChainId: ARBITRUM_SEPOLIA },
   ].map(n => {
     // If we are on testnet env, use testnet ids instead
     const chainId = isTestnet ? n.fallbackChainId : n.chainId;

--- a/packages/nextjs/components/Sidebar/NetworkChooserSidebar.tsx
+++ b/packages/nextjs/components/Sidebar/NetworkChooserSidebar.tsx
@@ -12,8 +12,7 @@ interface NetworkChooserSidebarProps {
   onSelectNetwork: (chainId: number | null) => void;
 }
 
-const NETWORKS_MAINNET = [26514, 8453];
-// Arbitrum Sepolia (421614) is testnet-only — no Arbitrum One mainnet entry.
+const NETWORKS_MAINNET = [26514, 8453, 42161];
 const NETWORKS_TESTNET = [2651420, 84532, 421614];
 
 export default function NetworkChooserSidebar({ isOpen, accounts, onSelectNetwork }: NetworkChooserSidebarProps) {

--- a/packages/nextjs/scaffold.config.ts
+++ b/packages/nextjs/scaffold.config.ts
@@ -68,10 +68,9 @@ const scaffoldConfig = {
   // The networks on which your DApp is live
   // targetNetworks: [chains.sepolia],
   // targetNetworks: [chains.hardhat],
-  // Arbitrum is testnet-only: zkVerify has a verifier on Arbitrum Sepolia but not Arbitrum One.
   targetNetworks:
     process.env.NEXT_PUBLIC_NETWORK === NetworkValue.mainnet
-      ? [horizenMainnet, chains.base]
+      ? [horizenMainnet, chains.base, chains.arbitrum]
       : [horizenTestnet, chains.baseSepolia, chains.arbitrumSepolia],
   // The interval at which your front-end polls the RPC servers for new data (it has no effect if you only target the local network (default is 4000))
   pollingInterval: RPC_POLLING_INTERVAL,

--- a/packages/nextjs/utils/network.ts
+++ b/packages/nextjs/utils/network.ts
@@ -29,7 +29,12 @@ const NETWORK_META_BY_CHAIN_ID: Record<number, NetworkMeta> = {
     icon: "/token/base.svg",
     badge: "/token/base.svg",
   },
-  // Arbitrum (testnet only). Add /token/arbitrum.svg asset for the icon/badge.
+  // Arbitrum
+  42161: {
+    name: "Arbitrum",
+    icon: "/token/arbitrum.svg",
+    badge: "/token/arbitrum.svg",
+  },
   421614: {
     name: "Arbitrum Sepolia",
     icon: "/token/arbitrum.svg",

--- a/packages/shared/src/chains/arbitrumOne.ts
+++ b/packages/shared/src/chains/arbitrumOne.ts
@@ -1,0 +1,6 @@
+import { arbitrum } from "viem/chains";
+
+// Re-export viem's Arbitrum One (42161) chain definition for consistency with
+// the other chains module. On Arbitrum the account contract is the Stylus
+// (Rust/WASM) port of MetaMultiSigWallet (same as Arbitrum Sepolia).
+export { arbitrum as arbitrumOne };

--- a/packages/shared/src/chains/index.ts
+++ b/packages/shared/src/chains/index.ts
@@ -3,6 +3,7 @@ import { horizenMainnet } from "./horizenMainnet";
 import { baseSepolia } from "./baseSepolia";
 import { baseMainnet } from "./baseMainnet";
 import { arbitrumSepolia } from "./arbitrumSepolia";
+import { arbitrumOne } from "./arbitrumOne";
 
 export {
   horizenTestnet,
@@ -10,6 +11,7 @@ export {
   baseSepolia,
   baseMainnet,
   arbitrumSepolia,
+  arbitrumOne,
 };
 
 export type NetworkType = "testnet" | "mainnet";
@@ -38,6 +40,8 @@ export const getChainById = (chainId: number) => {
       return baseMainnet;
     case arbitrumSepolia.id:
       return arbitrumSepolia;
+    case arbitrumOne.id:
+      return arbitrumOne;
     default:
       throw new Error(`Unsupported chainId: ${chainId}`);
   }

--- a/packages/shared/src/constants/chains.ts
+++ b/packages/shared/src/constants/chains.ts
@@ -1,0 +1,12 @@
+// Single source of truth for the EVM chain IDs PolyPay supports.
+// Reuse these everywhere instead of redeclaring magic numbers.
+export const CHAIN_IDS = {
+  HORIZEN_MAINNET: 26514,
+  HORIZEN_TESTNET: 2651420,
+  BASE_MAINNET: 8453,
+  BASE_SEPOLIA: 84532,
+  ARBITRUM_ONE: 42161,
+  ARBITRUM_SEPOLIA: 421614,
+} as const;
+
+export type SupportedChainId = (typeof CHAIN_IDS)[keyof typeof CHAIN_IDS];

--- a/packages/shared/src/constants/index.ts
+++ b/packages/shared/src/constants/index.ts
@@ -1,5 +1,6 @@
 export * from "./socket-events";
 export * from "./room";
+export * from "./chains";
 export * from "./token";
 export * from "./campaign";
 export * from "./contract";

--- a/packages/shared/src/constants/token.ts
+++ b/packages/shared/src/constants/token.ts
@@ -1,3 +1,5 @@
+import { CHAIN_IDS } from "./chains";
+
 export type TokenAddresses = Record<number, string>;
 
 export interface Token {
@@ -15,13 +17,15 @@ export interface ResolvedToken extends Omit<Token, "addresses"> {
 
 export const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
 
-// Chain IDs
-const HORIZEN_MAINNET = 26514;
-const HORIZEN_TESTNET = 2651420;
-const BASE_MAINNET = 8453;
-const BASE_SEPOLIA = 84532;
-// Arbitrum is testnet-only in PolyPay (zkVerify has no Arbitrum One verifier).
-const ARBITRUM_SEPOLIA = 421614;
+// Chain IDs (single source of truth in ./chains).
+const {
+  HORIZEN_MAINNET,
+  HORIZEN_TESTNET,
+  BASE_MAINNET,
+  BASE_SEPOLIA,
+  ARBITRUM_SEPOLIA,
+  ARBITRUM_ONE,
+} = CHAIN_IDS;
 
 const ALL_CHAIN_IDS = [
   HORIZEN_MAINNET,
@@ -29,6 +33,7 @@ const ALL_CHAIN_IDS = [
   BASE_MAINNET,
   BASE_SEPOLIA,
   ARBITRUM_SEPOLIA,
+  ARBITRUM_ONE,
 ];
 
 export const NATIVE_ETH: Token = {
@@ -80,6 +85,8 @@ export const USDC_TOKEN: Token = {
     [BASE_SEPOLIA]: "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
     // Circle official USDC on Arbitrum Sepolia (source: developers.circle.com).
     [ARBITRUM_SEPOLIA]: "0x75faf114eafb1BDbe2F0316DF893fd58CE46AA4d",
+    // Circle native USDC on Arbitrum One (NOT bridged USDC.e; source: developers.circle.com).
+    [ARBITRUM_ONE]: "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
   },
   symbol: "USDC",
   name: "USD Coin",

--- a/packages/shared/src/contracts/MetaMultiSigWalletStylus.ts
+++ b/packages/shared/src/contracts/MetaMultiSigWalletStylus.ts
@@ -22,6 +22,7 @@
 // Chains whose account contract is the Stylus port instead of the EVM .sol one.
 export const STYLUS_CHAIN_IDS: readonly number[] = [
   421614, // Arbitrum Sepolia
+  42161, // Arbitrum One
 ];
 
 export const isStylusChain = (chainId: number): boolean =>

--- a/packages/shared/src/contracts/contracts-config.ts
+++ b/packages/shared/src/contracts/contracts-config.ts
@@ -43,13 +43,26 @@ export const CONTRACT_CONFIG_BY_CHAIN_ID = {
     // Current build: original STATICCALL-based Poseidon (uses the on-chain
     // poseidon-solidity PoseidonT3 library at `poseidonT3Address`). The
     // in-process Rust Poseidon experiment was reverted — see NOTES.md.
-    stylusImplAddress: "0x0395b99f3a45bd08d018d3d3060a0e2bf8dc8978",
+    stylusImplAddress: "0x3e3f8bfb2dc0e2224808fa7da83e1cbbbf0a56ea",
     // Stylus/Rust EIP-1167 factory (packages/stylus-factory) bound to the
     // STATICCALL-Poseidon impl above. Emits byte-identical proxy bytecode to
     // the previous Solidity factory, so accounts created here are
     // indistinguishable on-chain from accounts created against the legacy
     // factory.
-    stylusFactoryAddress: "0xc35c0693286ebdc18bdf257f102dec9632a7ce77",
+    stylusFactoryAddress: "0xe4a4520b1ac45300cbe9d94723780d920681719d",
+  },
+  42161: {
+    // Arbitrum One mainnet. Account contract is the Stylus (Rust/WASM) port,
+    // same as Arbitrum Sepolia. zkVerify aggregation + vkHash match the other
+    // mainnets (Horizen/Base); PoseidonT3 is the deterministic CREATE2 address.
+    zkVerifyAddress: "0xCb47A3C3B9Eb2E549a3F2EA4729De28CafbB2b69",
+    vkHash:
+      "0xb3c5381523a496996868370791ec7ae490be7e2c996296fb67708daed8a6ea38",
+    poseidonT3Address: "0x3333333C0A88F9BE4fd23ed0536F9B6c427e3B93",
+    // Deployed in Phase 2 via cargo stylus on Arbitrum One. Zero-address
+    // sentinel until then (getStylusFactoryAddress throws on zero).
+    stylusImplAddress: "0x0000000000000000000000000000000000000000",
+    stylusFactoryAddress: "0x0000000000000000000000000000000000000000",
   },
 } as const;
 

--- a/packages/shared/src/contracts/contracts-config.ts
+++ b/packages/shared/src/contracts/contracts-config.ts
@@ -43,13 +43,13 @@ export const CONTRACT_CONFIG_BY_CHAIN_ID = {
     // Current build: original STATICCALL-based Poseidon (uses the on-chain
     // poseidon-solidity PoseidonT3 library at `poseidonT3Address`). The
     // in-process Rust Poseidon experiment was reverted — see NOTES.md.
-    stylusImplAddress: "0x3e3f8bfb2dc0e2224808fa7da83e1cbbbf0a56ea",
+    stylusImplAddress: "0x61fddf7cde02d4527b7d1086671d3f948e59f1d1",
     // Stylus/Rust EIP-1167 factory (packages/stylus-factory) bound to the
     // STATICCALL-Poseidon impl above. Emits byte-identical proxy bytecode to
     // the previous Solidity factory, so accounts created here are
     // indistinguishable on-chain from accounts created against the legacy
     // factory.
-    stylusFactoryAddress: "0xe4a4520b1ac45300cbe9d94723780d920681719d",
+    stylusFactoryAddress: "0x73d33f803600087ed1259035f9ff46f16f15c11a",
   },
   42161: {
     // Arbitrum One mainnet. Account contract is the Stylus (Rust/WASM) port,
@@ -61,8 +61,8 @@ export const CONTRACT_CONFIG_BY_CHAIN_ID = {
     poseidonT3Address: "0x3333333C0A88F9BE4fd23ed0536F9B6c427e3B93",
     // Deployed in Phase 2 via cargo stylus on Arbitrum One. Zero-address
     // sentinel until then (getStylusFactoryAddress throws on zero).
-    stylusImplAddress: "0x0000000000000000000000000000000000000000",
-    stylusFactoryAddress: "0x0000000000000000000000000000000000000000",
+    stylusImplAddress: "0x49e772bd7efd483c043402331fbf03533852850f",
+    stylusFactoryAddress: "0x740b6a46585474eb113f81999c1117e69d4be1be",
   },
 } as const;
 

--- a/packages/stylus/NOTES.md
+++ b/packages/stylus/NOTES.md
@@ -4,8 +4,8 @@ Stylus (Rust/WASM) port of `MetaMultiSigWallet` for Arbitrum. Each PolyPay
 account is an EIP-1167 minimal proxy in front of one shared Stylus impl, so
 account creation and `execute()` use normal EVM tooling.
 
-Stylus runs on Arbitrum Sepolia only. Arbitrum One is blocked by the Stylus
-code-size limit — see "Arbitrum One blocker" below.
+Runs on Arbitrum Sepolia, and on Arbitrum One after slimming the impl under the
+24 KiB code-size limit — see "Arbitrum One code-size limit" below.
 
 ## How it fits together
 
@@ -58,14 +58,25 @@ rewriting the Noir circuit + new vk + account migration); the
 circomlib-compatible Rust libs are std-only. STATICCALL is correct and not a
 bottleneck, so it stays.
 
-## Active build (Arbitrum Sepolia, 421614)
+## Active build (slim impl, 24295 bytes)
+
+Arbitrum Sepolia (421614):
 
 | Component | Address |
 |---|---|
-| Impl | `0x3e3f8bfb2dc0e2224808fa7da83e1cbbbf0a56ea` |
-| Factory | `0xe4a4520b1ac45300cbe9d94723780d920681719d` |
+| Impl | `0x61fddf7cde02d4527b7d1086671d3f948e59f1d1` |
+| Factory | `0x73d33f803600087ed1259035f9ff46f16f15c11a` |
 | PoseidonT3 | `0x3333333C0A88F9BE4fd23ed0536F9B6c427e3B93` |
 | zkVerify aggregation | `0xd007494945580eEb25522c8e0b2fa798B3F0FDE2` |
+
+Arbitrum One (42161), deployed 2026-06-10:
+
+| Component | Address |
+|---|---|
+| Impl | `0x49e772bd7efd483c043402331fbf03533852850f` |
+| Factory | `0x740b6a46585474eb113f81999c1117e69d4be1be` |
+| PoseidonT3 | `0x3333333C0A88F9BE4fd23ed0536F9B6c427e3B93` |
+| zkVerify aggregation | `0xCb47A3C3B9Eb2E549a3F2EA4729De28CafbB2b69` |
 
 ## Code map
 
@@ -77,39 +88,45 @@ bottleneck, so it stays.
   (`deployStylusAccount` -> `factory.createWallet`)
 - Frontend: `packages/nextjs/scaffold.config.ts`, `utils/network.ts`
 
-## Arbitrum One blocker — Stylus code-size limit
+## Arbitrum One code-size limit — resolved by slimming the impl
 
-As of 2026-06-10 the Stylus impl does not deploy to Arbitrum One: the deploy
-reverts with empty `execution reverted, data: "0x"`. The brotli-compressed
-Stylus code-size limit is 24576 bytes (24 KiB), same as the EVM. The impl is
-31202 bytes (2 fragments), over the limit. zkVerify mainnet is available on
-Arbitrum One; the size limit is the only blocker.
+The brotli-compressed Stylus code-size limit is 24576 bytes (24 KiB), same as
+the EVM; deploying over it reverts with empty `execution reverted, data: "0x"`.
+The original impl was 31202 bytes (2 fragments) and would not deploy to
+Arbitrum One. ArbOS 60 "Elara" raises this limit (live on Arbitrum Sepolia
+2026-05-18, not yet on Arbitrum One, pending an on-chain vote with no firm
+date), but instead the impl was slimmed to 24295 bytes (1 fragment), which
+deploys on Arbitrum One today without waiting for ArbOS 60.
 
-Findings:
-- `stylusVersion()` on ArbWasm (`0x...071`): Arbitrum One = 2, Arbitrum Sepolia = 3.
-- The limit is 24576 bytes: on Arbitrum One a 24323-byte contract (1 fragment)
-  deploy-estimates successfully; a 24618-byte contract (2 fragments) reverts `0x`.
-- The revert is at code storage, not activation: `--no-activate` still reverts,
-  and a small Stylus contract deploys on Arbitrum One.
+How the impl was slimmed (31202 -> 24295 bytes):
+- Removed the on-chain events (Deposit / TransactionExecuted / Owner). The app
+  tracks transactions via the backend DB + relayer, not on-chain logs, so there
+  is no functional impact. Largest saving (~6 KB — alloy event encoding for
+  dynamic bytes).
+- Hand-rolled the PoseidonT3 and zkVerify STATICCALLs instead of the generated
+  `sol_interface!` bindings (internal only, no ABI change).
 
-**ArbOS 60 "Elara"** raises the Stylus code-size limit. Live on Arbitrum
-Sepolia since 2026-05-18 (why the 31 KB impl deploys there). NOT yet on
-Arbitrum One — pending an on-chain Constitutional vote; **no firm mainnet date**.
-- Upgrade notice: https://docs.arbitrum.io/notices/arbos60-upgrade-notice
-- AIP / governance status: https://forum.arbitrum.foundation/t/constitutional-aip-arbos-60-elara/30601
+Kept unchanged: execute (same ABI, `ZkProof[]`), transfer, batch_transfer,
+batch_transfer_multi, signer management, getters, proof verification. No backend
+or frontend changes required (only the events were dropped from the ABI).
+
+Margin is 281 bytes under 24576. Future additions can push it back over the
+limit (-> 2 fragments -> will not deploy on Arbitrum One until ArbOS 60).
+
+Tested on Arbitrum Sepolia 2026-06-10: a new account against the slim impl ran a
+transfer and a batch successfully (proof verification passed), confirming the
+hand-rolled poseidon/zkVerify calls.
+
+References:
 - 24 KB Stylus limit: https://docs.arbitrum.io/stylus/how-tos/optimizing-binaries
+- ArbOS 60 (raises the limit): https://docs.arbitrum.io/notices/arbos60-upgrade-notice
 
-Options for Arbitrum One:
-1. Wait for ArbOS 60 on Arbitrum One, then redeploy the same impl — no code
-   change. ETA unknown (governance).
-2. Ship the Solidity `MetaMultiSigWallet.sol` on Arbitrum One instead (EVM
-   bytecode is under 24 KB), keeping Stylus only on Arbitrum Sepolia. Works on
-   the same deploy path as Base/Horizen; PoseidonT3 is already deployed on
-   Arbitrum One. Trade-off: the mainnet wallet would be EVM, not Stylus.
-3. Shrink the impl under 24576 bytes compressed — impractical without cutting
-   features (best wasm-opt result was ~29 KB compressed).
+Next: deploy the slim impl to Arbitrum One via `deploy-arbitrum-one.sh`, then run
+the same transfer/batch test on Arbitrum One.
 
-Decision (2026-06-10): option 1. Stylus on mainnet is required, so the Solidity
-wallet (option 2) is not used. Arbitrum One mainnet is deferred until ArbOS 60
-activates there; Phase 1 wiring stays in place, deploy via
-`deploy-arbitrum-one.sh` once `stylusVersion()` on Arbitrum One returns 3.
+The slimming is a temporary measure to fit the current 24 KiB limit. Once ArbOS
+60 is live on Arbitrum One (`stylusVersion()` returns 3, the limit is raised),
+revert the slim changes — restore the on-chain events (Deposit /
+TransactionExecuted / Owner); the `sol_interface!` hand-roll can stay since it
+has no functional downside — then redeploy the full impl on both chains. The
+pre-slim impl is the parent commit of the slimming commit.

--- a/packages/stylus/NOTES.md
+++ b/packages/stylus/NOTES.md
@@ -1,269 +1,115 @@
-# Arbitrum Stylus support — status
+# Arbitrum Stylus support
 
-Working notes for the `feat/arbitrum-support` branch. The Stylus port of
-`MetaMultiSigWallet` is wired end-to-end: per-account wallets are created as
-EIP-1167 minimal proxies in front of a single Stylus implementation, so account
-creation and `execute` both flow through normal EVM tooling on Arbitrum.
+Stylus (Rust/WASM) port of `MetaMultiSigWallet` for Arbitrum. Each PolyPay
+account is an EIP-1167 minimal proxy in front of one shared Stylus impl, so
+account creation and `execute()` use normal EVM tooling.
 
-## Architecture
+Stylus runs on Arbitrum Sepolia only. Arbitrum One is blocked by the Stylus
+code-size limit — see "Arbitrum One blocker" below.
 
-- **Stylus impl** (`packages/stylus/src/lib.rs`) — deployed ONCE per chain via
-  `cargo stylus deploy`. Holds all the WASM logic (signer set, nonce/nullifier
-  tracking, ZK proof verification through zkVerify, batch transfers). Exposes
-  both `constructor(...)` (used at impl deploy by cargo-stylus) and `init(...)`
-  with identical args; an `initialized` storage flag guards against double
-  init.
-- **Factory** (`packages/stylus-factory/src/lib.rs`) — Rust/Stylus contract,
-  deployed once, parameterized by the impl address. `createWallet(...)` builds
-  the 62-byte proxy creation bytecode in pure Rust, deploys it via
-  `RawDeploy` (CREATE), then calls `init(...)` on the clone. Bubbles up the
-  underlying revert reason on failure. A legacy Solidity factory at
-  `packages/hardhat/contracts/MetaMultiSigWalletStylusFactory.sol` is kept as
-  a reference; both factories emit byte-identical proxy bytecode (unit test
-  in `packages/stylus-factory/src/lib.rs` guards against drift).
-- **Per account** — every PolyPay account on Arbitrum Sepolia is one EIP-1167
-  proxy with its own storage (signers/nonces/nullifiers) delegating into the
-  shared impl's WASM. `execute(...)` calls go through the proxy and are
-  delegatecalled into the Stylus runtime, which sees the proxy's storage as
-  its own — confirmed compatible per the Stylus Saturdays "Writing proxies in
-  Arbitrum Stylus" issue (2024-09-21).
+## How it fits together
 
-## Why this shape
+- **Impl** — `packages/stylus/src/lib.rs`. Deployed once per chain via
+  `cargo stylus deploy`. Holds all logic (signers, nonces/nullifiers, ZK proof
+  verification, batch transfers). Has `constructor(...)` (run at deploy) and
+  `init(...)` (run on each clone); an `initialized` flag blocks double-init.
+- **Factory** — `packages/stylus-factory/src/lib.rs`. Deployed once, bound to
+  the impl address. `createWallet(...)` deploys an EIP-1167 proxy and `init`s
+  it in one tx.
+- **Per account** — one EIP-1167 proxy with its own storage, delegatecalling
+  into the shared impl.
 
-- The Stylus impl is ~29 KB brotli-compressed (the on-chain form), above the
-  24 KB EVM code-size limit, so cargo-stylus fragments it across two
-  contracts. That makes the single-bytecode `StylusDeployer.deploy(bytecode,
-  initData, ...)` path unusable for per-account creation: `cargo stylus
-  get-initcode` errors with "fragmented contracts not currently supported".
-- Shrinking under 24 KB was not realistic: `wasm-opt -Oz` cut the raw wasm 97 KB
-  → 76 KB (-22%) but compressed size barely moved (30.5 KB → 29 KB) because
-  brotli already removes that redundancy, and dropping public getters / the
-  dynamic ABI codec only saved ~0.8 KB compressed. The bulk is core multisig
-  logic + alloy ABI codec for `ZkProof` + keccak + Stylus runtime.
-- EIP-1167 sidesteps the limit entirely — the proxy is plain EVM bytecode,
-  unfragmented, and the impl is deployed exactly once.
+Why a proxy instead of a fresh Stylus contract per account: the impl is ~31 KB
+compressed (>24 KB EVM limit), so cargo-stylus fragments it and the
+single-bytecode deploy path can't be used per-account. The proxy is plain EVM
+bytecode and sidesteps this.
 
-## Operational steps
+## Deploy
 
-1. Deploy the Stylus impl: `cd packages/stylus && cargo stylus deploy
-   --no-verify --max-fee-per-gas-gwei 0.1 --constructor-args <args>`. Use any
-   valid set of constructor args (e.g. the existing test args); the impl's own
-   storage is unused since all live state lives in proxies.
-2. Update `stylusImplAddress` for chain 421614 in
-   `packages/shared/src/contracts/contracts-config.ts` with the new impl
-   address.
-3. Deploy the Rust/Stylus factory pointing at the new impl:
-   `cd packages/stylus-factory && cargo stylus deploy \`
-   `  --endpoint https://sepolia-rollup.arbitrum.io/rpc \`
-   `  --private-key 0x<pk> --no-verify --max-fee-per-gas-gwei 0.1 \`
-   `  --constructor-args 0x<impl>`
-4. Update `stylusFactoryAddress` for chain 421614 in the same shared config.
-5. Backend can now deploy accounts on Arbitrum Sepolia without any extra env
-   vars.
+Use `packages/stylus/deploy-arbitrum-sepolia.sh` — deploys impl + factory and
+patches `stylusImplAddress` / `stylusFactoryAddress` (chain 421614) in
+`packages/shared/src/contracts/contracts-config.ts`.
 
-### On-chain reference addresses (Arbitrum Sepolia, chain 421614)
+```bash
+export PK=0x<deployer-key-with-arb-sepolia-eth>
+bash packages/stylus/deploy-arbitrum-sepolia.sh
+```
 
-- PoseidonT3 (deterministic): `0x3333333C0A88F9BE4fd23ed0536F9B6c427e3B93`
-  (deploy via `yarn deploy --tags PoseidonT3 --network arbitrumSepolia`)
-- zkVerify aggregation (proxy): `0xd007494945580eEb25522c8e0b2fa798B3F0FDE2`
-- Stylus impl: redeploy from this branch (has `init()` + `initialized` guard);
-  the previous test wallet at `0x1e8483112db2c393ef28185768a2aaa52a453b9b` was
-  the pre-proxy version.
+PoseidonT3 must already be on-chain (deterministic
+`0x3333333C0A88F9BE4fd23ed0536F9B6c427e3B93`; redeploy with
+`yarn deploy --tags PoseidonT3 --network arbitrumSepolia` if missing).
+
+## Self-call routing (onlySelf functions)
+
+`execute()` routes a self-call (`to == address(this)`) for the onlySelf
+functions (`addSigners`, `removeSigners`, `updateSignaturesRequired`,
+`batchTransfer`, `batchTransferMulti`) through `dispatch_self_call` instead of
+an EVM `CALL`: it matches the 4-byte selector, decodes the calldata, and calls
+the matching `*_internal` helper directly. This avoids a Stylus
+delegatecall-context `msg.sender` quirk that broke the original
+`address(this).call(...)` path. Covered by unit tests in `src/lib.rs`.
+
+## Poseidon: STATICCALL only
+
+`verify_proof` STATICCALLs the on-chain PoseidonT3 library. Porting Poseidon
+into the impl was researched and rejected: the only Stylus-native lib (OZ
+`poseidon2`) is a different algorithm with different output (would require
+rewriting the Noir circuit + new vk + account migration); the
+circomlib-compatible Rust libs are std-only. STATICCALL is correct and not a
+bottleneck, so it stays.
+
+## Active build (Arbitrum Sepolia, 421614)
+
+| Component | Address |
+|---|---|
+| Impl | `0x3e3f8bfb2dc0e2224808fa7da83e1cbbbf0a56ea` |
+| Factory | `0xe4a4520b1ac45300cbe9d94723780d920681719d` |
+| PoseidonT3 | `0x3333333C0A88F9BE4fd23ed0536F9B6c427e3B93` |
+| zkVerify aggregation | `0xd007494945580eEb25522c8e0b2fa798B3F0FDE2` |
 
 ## Code map
 
-- Stylus impl + build/deploy guide: `packages/stylus/` (`src/lib.rs`,
-  `README.md`).
-- Stylus factory (Rust/WASM): `packages/stylus-factory/src/lib.rs`. Build
-  with `cargo stylus deploy` from that directory.
-- Legacy Solidity factory (kept as reference, not wired into the app):
-  `packages/hardhat/contracts/MetaMultiSigWalletStylusFactory.sol`,
-  `packages/hardhat/deploy/02_deploy_stylus_factory.ts`.
-- Shared addresses + ABIs: `packages/shared/src/chains/arbitrumSepolia.ts`,
-  `contracts/contracts-config.ts` (421614 entry,
-  `stylusImplAddress`/`stylusFactoryAddress`),
-  `contracts/MetaMultiSigWalletStylus.ts` (factory ABI + `isStylusChain`).
-- Backend relayer: `packages/backend/src/relayer-wallet/relayer-wallet.service.ts`
-  (`deployStylusAccount` now routes through `factory.createWallet`).
-- Frontend: `packages/nextjs/scaffold.config.ts`, `utils/network.ts`.
-- PoseidonT3 deploy script: `packages/hardhat/deploy/01_deploy_poseidon_t3.ts`.
+- Impl + build guide: `packages/stylus/` (`src/lib.rs`, `README.md`)
+- Factory: `packages/stylus-factory/src/lib.rs`
+- Shared config: `packages/shared/src/contracts/contracts-config.ts` (421614),
+  `chains/arbitrumSepolia.ts`, `contracts/MetaMultiSigWalletStylus.ts`
+- Relayer: `packages/backend/src/relayer-wallet/relayer-wallet.service.ts`
+  (`deployStylusAccount` -> `factory.createWallet`)
+- Frontend: `packages/nextjs/scaffold.config.ts`, `utils/network.ts`
 
-## Open issue — `execute()` self-call reverts with `WalletError("Tx failed")`
+## Arbitrum One blocker — Stylus code-size limit
 
-Submitting an `add_signer` (or any onlySelf) transaction through `execute()` on
-the Arbitrum proxy reverts with `0x78cd39ed` = `WalletError(string)` payload
-`"Tx failed"`. That string only comes from the `.map_err(|_| err("Tx failed"))`
-wrapper around the inner self-call in `execute()`, so the actual revert is
-swallowed at that layer.
+As of 2026-06-10 the Stylus impl does not deploy to Arbitrum One: the deploy
+reverts with empty `execution reverted, data: "0x"`. The brotli-compressed
+Stylus code-size limit is 24576 bytes (24 KiB), same as the EVM. The impl is
+31202 bytes (2 fragments), over the limit. zkVerify mainnet is available on
+Arbitrum One; the size limit is the only blocker.
 
-### What we observed (not a confirmed root-cause — just a guess)
+Findings:
+- `stylusVersion()` on ArbWasm (`0x...071`): Arbitrum One = 2, Arbitrum Sepolia = 3.
+- The limit is 24576 bytes: on Arbitrum One a 24323-byte contract (1 fragment)
+  deploy-estimates successfully; a 24618-byte contract (2 fragments) reverts `0x`.
+- The revert is at code storage, not activation: `--no-activate` still reverts,
+  and a small Stylus contract deploys on Arbitrum One.
 
-`eth_call` probes on Arbitrum Sepolia against proxy
-`0x44Fe2002723a7975cefc784DFeF101c1D523Ac91` (impl
-`0x0907a7c0e73ef119d06e082914fc83aad1465aae`):
+**ArbOS 60 "Elara"** raises the Stylus code-size limit. Live on Arbitrum
+Sepolia since 2026-05-18 (why the 31 KB impl deploys there). NOT yet on
+Arbitrum One — pending an on-chain Constitutional vote; **no firm mainnet date**.
+- Upgrade notice: https://docs.arbitrum.io/notices/arbos60-upgrade-notice
+- AIP / governance status: https://forum.arbitrum.foundation/t/constitutional-aip-arbos-60-elara/30601
+- 24 KB Stylus limit: https://docs.arbitrum.io/stylus/how-tos/optimizing-binaries
 
-- `addSigners(...)` direct, `from = proxy` → succeeds (so the function body
-  itself and `only_self()` are fine when `msg.sender == address(this)`).
-- `addSigners(...)` direct, `from = impl` or `from = relayer EOA` →
-  `WalletError("Not Self")`.
-- Full `execute(...)` end-to-end → `WalletError("Tx failed")` (= inner call
-  reverted, original reason hidden).
+Options for Arbitrum One:
+1. Wait for ArbOS 60 on Arbitrum One, then redeploy the same impl — no code
+   change. ETA unknown (governance).
+2. Ship the Solidity `MetaMultiSigWallet.sol` on Arbitrum One instead (EVM
+   bytecode is under 24 KB), keeping Stylus only on Arbitrum Sepolia. Works on
+   the same deploy path as Base/Horizen; PoseidonT3 is already deployed on
+   Arbitrum One. Trade-off: the mainnet wallet would be EVM, not Stylus.
+3. Shrink the impl under 24576 bytes compressed — impractical without cutting
+   features (best wasm-opt result was ~29 KB compressed).
 
-### Working hypothesis
-
-When the Stylus impl runs in the proxy's delegatecall context and issues an
-outgoing `CALL` via `Call::new_payable(self, value)` + `call(...)`, the
-`msg.sender` of the new frame may not be `address(this)` (= proxy address) as
-standard EVM semantics would dictate. If Stylus's CALL host uses a cached
-"self address" set at activation (= impl address) instead of reading
-`address(this)` at runtime, the inner call would arrive at the proxy with
-`msg.sender = impl`, which delegatecalls back into the impl with that same
-`msg.sender`, failing `only_self()`.
-
-**This is a guess, not verified.** We did NOT:
-- Instrument the impl to log `msg.sender` of the inner frame
-- Inspect Stylus SDK / Nitro source to confirm the host call sets `msg.sender`
-  to address(this) at runtime vs. a cached value
-- File or find a matching upstream issue (issue #4114 on `OffchainLabs/nitro`
-  about Stylus-to-Stylus revert/return data being lost is in the same area but
-  isn't the same bug)
-
-The pattern works fine on the original Solidity contract (Horizen/Base), where
-`address(this).call(data)` from a delegatecalled implementation correctly
-delivers `msg.sender = address(this)`.
-
-### Status after the workaround
-
-On-chain results after deploying the new impl (with `dispatch_self_call`) and
-factory:
-
-- **`batch_transfer` via `execute()` → PASS** on Arbitrum Sepolia. So the
-  internal dispatcher reaches the `*_internal` helpers and storage / external
-  CALLs from there work fine.
-- **`add_signer` via `execute()` → still reverts with
-  `WalletError("Tx failed")`**. Same selector as before. We did not dig
-  further — left as an open core-team item.
-
-Possible directions (NOT investigated):
-- Difference between `add_signers_internal` and `batch_transfer_internal` is
-  mostly that the former mutates `commitments: uint256[]` storage (push) and
-  emits an `Owner` event per element, while the latter makes external CALLs.
-  Maybe Stylus storage array push under delegatecall has an issue, or the ABI
-  decode of `uint256[]` in `dispatch_self_call` (hand-rolled) is wrong for
-  some encoding.
-- Verify the decoded `(commitments, sig_required)` from the inner self-call
-  calldata matches what was submitted — could be off-by-one in the offset
-  math.
-- Try `remove_signers` / `update_signatures_required` to narrow which
-  internal is broken.
-
-### Workaround (implemented in lib.rs — partially works)
-
-`execute()` detects `to == self.vm().contract_address()` and routes the call
-through a Rust-level dispatcher (`dispatch_self_call`) that matches the
-selector against the onlySelf functions and invokes their `*_internal`
-helpers directly. This bypasses the EVM `CALL` round-trip entirely, so
-whatever Stylus is doing wrong with `msg.sender` in delegatecall-then-CALL no
-longer matters for self-calls.
-
-Each onlySelf public method (`add_signers`, `remove_signers`,
-`update_signatures_required`, `batch_transfer`, `batch_transfer_multi`) is now
-a thin wrapper that runs `only_self()` and delegates to its `*_internal`
-sibling. External direct calls keep their `only_self()` protection unchanged;
-only the in-process self-call from `execute()` bypasses it (and execute's own
-ZK-proof gating provides the access control).
-
-`dispatch_self_call` hand-rolls Solidity ABI decoding for the static set of
-parameter shapes used (`uint256`, `uint256[]`, `address[]`) to avoid pulling
-the full alloy ABI codec into the WASM (the impl is already over the 24 KB
-fragmentation threshold).
-
-Re-deploy is required (impl bytecode changed). Factory does not need to
-change. Update `stylusImplAddress` in
-`packages/shared/src/contracts/contracts-config.ts` after re-deploy.
-
-## Future: in-process Poseidon (no STATICCALL)
-
-Today `verify_proof` `STATICCALL`s the deployed `poseidon-solidity` PoseidonT3
-contract (`0x3333333C0A88F9BE4fd23ed0536F9B6c427e3B93`) for every proof. The
-output is validated bit-identical to the Noir circuit's `bn254::hash_2`, so
-the cross-contract call is correct — just adds ~5 KB gas per proof vs hashing
-in-process.
-
-Researched options (2026-06-04) for porting Poseidon into the Stylus impl:
-
-| Source | Variant | Compat with Noir `bn254::hash_2`? | no_std / Stylus-ready? |
-|---|---|---|---|
-| [OZ `rust-contracts-stylus/poseidon2`](https://github.com/OpenZeppelin/rust-contracts-stylus/blob/main/lib/crypto/src/poseidon2/mod.rs) | **Poseidon2** | ❌ different algorithm, different output | ✅ |
-| [`light-poseidon` v0.4.0](https://github.com/Lightprotocol/light-poseidon) (Sep 2025) | Original Poseidon, circomlib-compatible (x^5 S-box, BN254, t=3, 8 full + 57 partial rounds) | ✅ very likely (params match circomlib) | ❌ `thiserror = "1.0"` is std-only; `ark-ff`/`ark-bn254` deps not gated with `no_std` features |
-| [`TaceoLabs/poseidon-rust`](https://github.com/TaceoLabs/poseidon-rust) | Original, Circom-compatible | ⚠️ likely yes | ❓ unverified, no tagged releases |
-| Custom in-tree crate using `ark-ff` + `ark-bn254` (both no_std-ready behind a feature flag) + circomlib constants | Original by construction | ✅ | ✅ — verified by spike 2026-06-04, see below |
-
-**Conclusion**: cannot drop in any existing crate as-is. Two viable paths if
-we decide the gas saving is worth it:
-
-1. **Fork `light-poseidon`** — swap `thiserror` for a hand-rolled error type,
-   add `#![no_std]` + `extern crate alloc`, enable `no_std` features on the
-   `ark-*` deps. ~1–2 days, we own the fork.
-2. **Write a ~200-line in-tree Poseidon** using `ark-ff` / `ark-bn254` with
-   hardcoded circomlib constants. More code, fully under our control, no
-   third-party fork to maintain. ~2–3 days plus a parity harness against the
-   on-chain `PoseidonT3` (we already have the testing harness).
-
-Either path MUST end with a bit-for-bit parity check vs
-`PoseidonT3.hash([a,b])` on a set of vectors before swapping into
-`verify_proof`. The current STATICCALL path is correct and not blocking the
-demo, so this is opportunistic optimization, not on the critical path.
-
-### Spike verified (2026-06-04)
-
-Confirmed `ark-ff` 0.5 + `ark-bn254` 0.5 build clean to the Stylus WASM
-target (`wasm32-unknown-unknown`, `--release`) and `cargo stylus check`
-against Arbitrum Sepolia succeeds. Required Cargo.toml flags:
-
-```toml
-ark-ff = { version = "0.5.0", default-features = false }
-ark-bn254 = { version = "0.5.0", default-features = false, features = ["scalar_field"] }
-```
-
-Contract size before adding the deps: 31.1 KB / 2 fragments. After the spike
-(with a trivial `Fr::one() != Fr::zero()` touch): 31.1 KB / 2 fragments —
-unused arkworks code was stripped by the linker, so the real size impact only
-shows up once a full Poseidon round function is wired in. Headroom is fine
-since cargo-stylus already handles fragmentation for us.
-
-So path 2 (custom in-tree Poseidon) is **dep-level unblocked**. Remaining
-work is the algorithm + circomlib constants + parity harness.
-
-## Poseidon stays as STATICCALL — not portable to Stylus
-
-The Stylus impl keeps calling the on-chain `PoseidonT3` Solidity library
-(`0x3333333C0A88F9BE4fd23ed0536F9B6c427e3B93`) via STATICCALL for every
-`verify_proof`. Porting Poseidon into the Stylus contract is **not feasible**
-without breaking compatibility with our Noir circuit:
-
-- **OpenZeppelin `rust-contracts-stylus/poseidon2`** — the only Stylus-native
-  Poseidon library — implements **Poseidon2**, a different algorithm with
-  different constants and different output. Using it requires rewriting the
-  Noir circuit, regenerating the UltraHonk verification key, re-registering
-  the new vk on zkVerify, and migrating every existing account.
-- **`light-poseidon`** / **`TaceoLabs/poseidon-rust`** — right algorithm
-  (original Poseidon, circomlib-compatible), but std-only. Don't build for
-  the Stylus WASM target without a fork.
-
-Hand-rolling Poseidon in our own crate would get the math right but defeats
-the only reason to do this in the first place (marketing: "uses a real
-Stylus Poseidon library"). So we leave it on STATICCALL.
-
-### Active build
-
-| Component | Address | Source |
-|---|---|---|
-| Impl (Rust/Stylus, STATICCALLs PoseidonT3) | `0x0395b99f3a45bd08d018d3d3060a0e2bf8dc8978` | `packages/stylus/src/lib.rs` |
-| Factory (Rust/Stylus) | `0xc35c0693286ebdc18bdf257f102dec9632a7ce77` | `packages/stylus-factory/src/lib.rs` |
-| PoseidonT3 (on-chain library) | `0x3333333C0A88F9BE4fd23ed0536F9B6c427e3B93` | poseidon-solidity, deterministic |
-
-## Constraint reminder
-
-Arbitrum is **testnet-only** in PolyPay: zkVerify has a verifier on Arbitrum
-Sepolia but not Arbitrum One mainnet, so this cannot go to production yet.
+Decision (2026-06-10): option 1. Stylus on mainnet is required, so the Solidity
+wallet (option 2) is not used. Arbitrum One mainnet is deferred until ArbOS 60
+activates there; Phase 1 wiring stays in place, deploy via
+`deploy-arbitrum-one.sh` once `stylusVersion()` on Arbitrum One returns 3.

--- a/packages/stylus/deploy-arbitrum-one.sh
+++ b/packages/stylus/deploy-arbitrum-one.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+#
+# Deploy the full PolyPay Stylus stack to Arbitrum ONE MAINNET (42161):
+#   0. PoseidonT3 hashing library (hardhat, deterministic CREATE2 -> 0x3333...)
+#   1. Stylus impl            (cargo stylus, packages/stylus)
+#   2. Rust EIP-1167 factory  (cargo stylus, packages/stylus-factory, bound to impl)
+#   3. patch stylusImplAddress / stylusFactoryAddress for chain 42161 in
+#      packages/shared/src/contracts/contracts-config.ts
+#
+# This spends REAL ETH on Arbitrum One. Requires:
+#   - cargo-stylus installed
+#   - PK exported with a deployer key funded with Arbitrum One ETH
+#
+# Usage:
+#   export PK=0x<deployer-key>
+#   bash packages/stylus/deploy-arbitrum-one.sh
+#
+# PoseidonT3 deploy is idempotent: if the deterministic library already exists
+# on Arbitrum One it is skipped.
+
+set -euo pipefail
+
+# --- config (Arbitrum One, chain 42161) -------------------------------------
+RPC="${RPC:-https://arb1.arbitrum.io/rpc}"   # cargo-stylus endpoint
+ZKV="0xCb47A3C3B9Eb2E549a3F2EA4729De28CafbB2b69"
+VKHASH="0xb3c5381523a496996868370791ec7ae490be7e2c996296fb67708daed8a6ea38"
+POSEIDON="0x3333333C0A88F9BE4fd23ed0536F9B6c427e3B93"
+CHAIN_ID="42161"
+COMMITMENTS="[1]"   # impl storage is unused; any valid non-zero set works
+SIGS="1"
+GAS_FLAGS="${GAS_FLAGS:---no-verify --max-fee-per-gas-gwei 0.1}"
+
+# --- resolve paths ----------------------------------------------------------
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+STYLUS_DIR="$SCRIPT_DIR"
+FACTORY_DIR="$SCRIPT_DIR/../stylus-factory"
+HARDHAT_DIR="$SCRIPT_DIR/../hardhat"
+CONFIG="$SCRIPT_DIR/../shared/src/contracts/contracts-config.ts"
+
+# --- preflight --------------------------------------------------------------
+if [[ -z "${PK:-}" ]]; then
+  echo "ERROR: export PK=0x<deployer-key> first (key is never printed)." >&2
+  exit 1
+fi
+command -v cargo >/dev/null || { echo "ERROR: cargo not found." >&2; exit 1; }
+cargo stylus --version >/dev/null || { echo "ERROR: cargo-stylus not installed." >&2; exit 1; }
+[[ -f "$CONFIG" ]] || { echo "ERROR: config not found at $CONFIG" >&2; exit 1; }
+
+# --- mainnet guard ----------------------------------------------------------
+echo "About to deploy to ARBITRUM ONE MAINNET (42161) using RPC $RPC."
+echo "This spends real ETH. Type 'yes' to continue:"
+read -r CONFIRM
+[[ "$CONFIRM" == "yes" ]] || { echo "Aborted."; exit 1; }
+
+strip_ansi() { sed $'s/\x1b\\[[0-9;]*m//g'; }
+parse_addr() {
+  strip_ansi | grep -iE 'deployed code at address' | grep -oiE '0x[0-9a-f]{40}' | head -n1
+}
+
+# --- 0. PoseidonT3 (hardhat, deterministic) ---------------------------------
+echo "==> [0/3] Deploying PoseidonT3 on Arbitrum One (idempotent) ..."
+( cd "$HARDHAT_DIR" && __RUNTIME_DEPLOYER_PRIVATE_KEY="$PK" ARBITRUM_RPC="$RPC" \
+    npx hardhat deploy --tags PoseidonT3 --network arbitrum )
+
+# --- 1. Stylus impl ---------------------------------------------------------
+echo "==> [1/3] Deploying Stylus impl from $STYLUS_DIR ..."
+IMPL_LOG="$(mktemp)"
+( cd "$STYLUS_DIR" && cargo stylus deploy \
+    --endpoint "$RPC" \
+    --private-key "$PK" \
+    $GAS_FLAGS \
+    --constructor-args "$ZKV" "$VKHASH" "$POSEIDON" "$CHAIN_ID" "$COMMITMENTS" "$SIGS" \
+) 2>&1 | tee "$IMPL_LOG"
+
+IMPL_ADDR="$(parse_addr < "$IMPL_LOG")"
+[[ -n "$IMPL_ADDR" ]] || { echo "ERROR: could not parse impl address." >&2; exit 1; }
+echo "==> impl deployed at: $IMPL_ADDR"
+
+# --- 2. Rust EIP-1167 factory bound to the impl -----------------------------
+echo "==> [2/3] Deploying Rust factory from $FACTORY_DIR (impl=$IMPL_ADDR) ..."
+FACTORY_LOG="$(mktemp)"
+( cd "$FACTORY_DIR" && cargo stylus deploy \
+    --endpoint "$RPC" \
+    --private-key "$PK" \
+    $GAS_FLAGS \
+    --constructor-args "$IMPL_ADDR" \
+) 2>&1 | tee "$FACTORY_LOG"
+
+FACTORY_ADDR="$(parse_addr < "$FACTORY_LOG")"
+[[ -n "$FACTORY_ADDR" ]] || { echo "ERROR: could not parse factory address." >&2; exit 1; }
+echo "==> factory deployed at: $FACTORY_ADDR"
+
+# --- 3. patch shared contracts-config.ts (42161 zero sentinels only) --------
+# The 42161 entry is the only one with zero-address stylus addresses, so
+# replacing the 0x000..0 sentinels is unambiguous and never touches 421614.
+echo "==> [3/3] Patching $CONFIG (42161 stylusImpl / stylusFactory) ..."
+perl -0pi -e "s/(stylusImplAddress:\\s*\")0x0{40}(\")/\${1}${IMPL_ADDR}\${2}/" "$CONFIG"
+perl -0pi -e "s/(stylusFactoryAddress:\\s*\")0x0{40}(\")/\${1}${FACTORY_ADDR}\${2}/" "$CONFIG"
+
+echo ""
+echo "================ DONE (Arbitrum One) ================"
+echo "  PoseidonT3           = $POSEIDON (deterministic)"
+echo "  stylusImplAddress    = $IMPL_ADDR"
+echo "  stylusFactoryAddress = $FACTORY_ADDR"
+echo "  patched: $CONFIG"
+echo "logs: impl=$IMPL_LOG  factory=$FACTORY_LOG"
+echo ""
+echo "Next:"
+echo "  1. git diff packages/shared/src/contracts/contracts-config.ts"
+echo "  2. Add the 42161 MetaMultiSigWalletStylusFactory entry (address=$FACTORY_ADDR)"
+echo "     to packages/nextjs/contracts/deployedContracts.ts (reuse 421614 ABI)."
+echo "  3. yarn workspace @polypay/shared build"
+echo "  4. Verify zkVerify domain id 10 for 42161 in backend proof.ts before live."
+echo "  5. Fund the relayer (RELAYER_WALLET_KEY) with Arbitrum One ETH."

--- a/packages/stylus/deploy-arbitrum-sepolia.sh
+++ b/packages/stylus/deploy-arbitrum-sepolia.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+#
+# Deploy the PolyPay Stylus stack to Arbitrum Sepolia (421614) for testing:
+#   1. Stylus impl            (cargo stylus, packages/stylus)
+#   2. Rust EIP-1167 factory  (cargo stylus, packages/stylus-factory, bound to impl)
+#   3. patch stylusImplAddress / stylusFactoryAddress for chain 421614 in
+#      packages/shared/src/contracts/contracts-config.ts
+#
+# PoseidonT3 + zkVerify are already deployed on Arbitrum Sepolia.
+#
+# Usage:
+#   export PK=0x<deployer-key-with-arb-sepolia-eth>
+#   bash packages/stylus/deploy-arbitrum-sepolia.sh
+#
+# After deploy: create a NEW account on Arbitrum Sepolia (it will use the new
+# factory -> new impl) and run a transfer / batch to exercise execute().
+
+set -euo pipefail
+
+# --- config (Arbitrum Sepolia, chain 421614) --------------------------------
+RPC="${RPC:-https://sepolia-rollup.arbitrum.io/rpc}"
+ZKV="0xd007494945580eEb25522c8e0b2fa798B3F0FDE2"
+VKHASH="0xb3c5381523a496996868370791ec7ae490be7e2c996296fb67708daed8a6ea38"
+POSEIDON="0x3333333C0A88F9BE4fd23ed0536F9B6c427e3B93"
+CHAIN_ID="421614"
+COMMITMENTS="[1]"   # impl storage is unused; any valid non-zero set works
+SIGS="1"
+GAS_FLAGS="${GAS_FLAGS:---no-verify --max-fee-per-gas-gwei 0.1}"
+
+# --- resolve paths ----------------------------------------------------------
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+STYLUS_DIR="$SCRIPT_DIR"
+FACTORY_DIR="$SCRIPT_DIR/../stylus-factory"
+CONFIG="$SCRIPT_DIR/../shared/src/contracts/contracts-config.ts"
+
+# --- preflight --------------------------------------------------------------
+if [[ -z "${PK:-}" ]]; then
+  echo "ERROR: export PK=0x<deployer-key> first (key is never printed)." >&2
+  exit 1
+fi
+command -v cargo >/dev/null || { echo "ERROR: cargo not found." >&2; exit 1; }
+cargo stylus --version >/dev/null || { echo "ERROR: cargo-stylus not installed." >&2; exit 1; }
+[[ -f "$CONFIG" ]] || { echo "ERROR: config not found at $CONFIG" >&2; exit 1; }
+
+strip_ansi() { sed $'s/\x1b\\[[0-9;]*m//g'; }
+parse_addr() {
+  strip_ansi | grep -iE 'deployed code at address' | grep -oiE '0x[0-9a-f]{40}' | head -n1
+}
+
+# --- 1. Stylus impl ---------------------------------------------------------
+echo "==> [1/3] Deploying Stylus impl from $STYLUS_DIR ..."
+IMPL_LOG="$(mktemp)"
+( cd "$STYLUS_DIR" && cargo stylus deploy \
+    --endpoint "$RPC" \
+    --private-key "$PK" \
+    $GAS_FLAGS \
+    --constructor-args "$ZKV" "$VKHASH" "$POSEIDON" "$CHAIN_ID" "$COMMITMENTS" "$SIGS" \
+) 2>&1 | tee "$IMPL_LOG"
+
+IMPL_ADDR="$(parse_addr < "$IMPL_LOG")"
+[[ -n "$IMPL_ADDR" ]] || { echo "ERROR: could not parse impl address." >&2; exit 1; }
+echo "==> impl deployed at: $IMPL_ADDR"
+
+# --- 2. Rust EIP-1167 factory bound to the impl -----------------------------
+echo "==> [2/3] Deploying Rust factory from $FACTORY_DIR (impl=$IMPL_ADDR) ..."
+FACTORY_LOG="$(mktemp)"
+( cd "$FACTORY_DIR" && cargo stylus deploy \
+    --endpoint "$RPC" \
+    --private-key "$PK" \
+    $GAS_FLAGS \
+    --constructor-args "$IMPL_ADDR" \
+) 2>&1 | tee "$FACTORY_LOG"
+
+FACTORY_ADDR="$(parse_addr < "$FACTORY_LOG")"
+[[ -n "$FACTORY_ADDR" ]] || { echo "ERROR: could not parse factory address." >&2; exit 1; }
+echo "==> factory deployed at: $FACTORY_ADDR"
+
+# --- 3. patch shared contracts-config.ts (chain 421614 entry) ---------------
+# 421614 is the first entry in the file with these keys, so the non-global
+# substitution targets it (the 42161 entry comes after).
+echo "==> [3/3] Patching $CONFIG (421614 stylusImpl / stylusFactory) ..."
+perl -0pi -e "s/(stylusImplAddress:\\s*\")0x[0-9a-fA-F]+(\")/\${1}${IMPL_ADDR}\${2}/" "$CONFIG"
+perl -0pi -e "s/(stylusFactoryAddress:\\s*\")0x[0-9a-fA-F]+(\")/\${1}${FACTORY_ADDR}\${2}/" "$CONFIG"
+
+echo ""
+echo "================ DONE (Arbitrum Sepolia) ================"
+echo "  stylusImplAddress    = $IMPL_ADDR"
+echo "  stylusFactoryAddress = $FACTORY_ADDR"
+echo "  patched: $CONFIG"
+echo ""
+echo "Next:"
+echo "  1. git diff packages/shared/src/contracts/contracts-config.ts"
+echo "  2. yarn workspace @polypay/shared build"
+echo "  3. Create a NEW account on Arbitrum Sepolia (uses the new factory->impl),"
+echo "     then send a transfer and a batch to exercise execute() end-to-end."

--- a/packages/stylus/src/lib.rs
+++ b/packages/stylus/src/lib.rs
@@ -28,7 +28,7 @@ use stylus_sdk::{
     abi::Bytes,
     alloy_primitives::{uint, Address, B256, U256},
     alloy_sol_types::sol,
-    call::call,
+    call::{call, static_call},
     crypto::keccak,
     prelude::*,
     stylus_core::calls::Call,
@@ -60,10 +60,6 @@ sol! {
         uint256 index;
     }
 
-    event Deposit(address indexed sender, uint256 amount, uint256 balance);
-    event TransactionExecuted(uint256 indexed nonce, address to, uint256 value, bytes data, bytes result);
-    event Owner(uint256 indexed commitment, bool isAdded);
-
     error WalletError(string reason);
 }
 
@@ -74,23 +70,6 @@ pub enum Error {
 
 fn err(reason: &str) -> Error {
     Error::Wallet(WalletError { reason: reason.into() })
-}
-
-sol_interface! {
-    interface IVerifyProofAggregation {
-        function verifyProofAggregation(
-            uint256 domainId,
-            uint256 aggregationId,
-            bytes32 leaf,
-            bytes32[] merklePath,
-            uint256 leafCount,
-            uint256 index
-        ) external view returns (bool);
-    }
-
-    interface IPoseidonT3 {
-        function hash(uint256[2] inputs) external view returns (uint256);
-    }
 }
 
 sol_storage! {
@@ -211,14 +190,6 @@ impl MetaMultiSigWallet {
             call(self.vm(), context, to, &data_bytes).map_err(|_| err("Tx failed"))?
         };
 
-        self.vm().log(TransactionExecuted {
-            nonce,
-            to,
-            value,
-            data: data_bytes.into(),
-            result: result.clone().into(),
-        });
-
         Ok(result.into())
     }
 
@@ -302,11 +273,6 @@ impl MetaMultiSigWallet {
     #[receive]
     #[payable]
     pub fn receive(&mut self) -> Result<(), Vec<u8>> {
-        let sender = self.vm().msg_sender();
-        let amount = self.vm().msg_value();
-        let addr = self.vm().contract_address();
-        let balance = self.vm().balance(addr);
-        self.vm().log(Deposit { sender, amount, balance });
         Ok(())
     }
 }
@@ -346,7 +312,6 @@ impl MetaMultiSigWallet {
                 }
             }
             self.commitments.push(nc);
-            self.vm().log(Owner { commitment: nc, isAdded: true });
         }
 
         self.signatures_required.set(new_sig_required);
@@ -382,7 +347,6 @@ impl MetaMultiSigWallet {
                     self.commitments.setter(j).unwrap().set(last);
                     self.commitments.pop();
                     found = true;
-                    self.vm().log(Owner { commitment: *target, isAdded: false });
                     break;
                 }
             }
@@ -609,7 +573,6 @@ impl MetaMultiSigWallet {
                 return Err(err("Invalid commitment"));
             }
             self.commitments.push(*c);
-            self.vm().log(Owner { commitment: *c, isAdded: true });
         }
 
         self.initialized.set(true);
@@ -648,10 +611,17 @@ impl MetaMultiSigWallet {
     fn poseidon_hash2_internal(&mut self, a: U256, b: U256) -> Result<U256, Error> {
         let safe_a = a % BN254_PRIME;
         let safe_b = b % BN254_PRIME;
-        let poseidon = IPoseidonT3::new(self.poseidon_t3.get());
-        poseidon
-            .hash(self.vm(), Call::new(), [safe_a, safe_b])
-            .map_err(|_| err("Poseidon call failed"))
+        // hash(uint256[2]) — static array, encoded inline as two words.
+        let mut cd = Vec::with_capacity(68);
+        cd.extend_from_slice(&[0x56, 0x15, 0x58, 0xfe]);
+        cd.extend_from_slice(&safe_a.to_be_bytes::<32>());
+        cd.extend_from_slice(&safe_b.to_be_bytes::<32>());
+        let ret = static_call(self.vm(), Call::new(), self.poseidon_t3.get(), &cd)
+            .map_err(|_| err("Poseidon call failed"))?;
+        if ret.len() < 32 {
+            return Err(err("Poseidon call failed"));
+        }
+        Ok(U256::from_be_slice(&ret[..32]))
     }
 
     fn verify_proof(&mut self, tx_hash: B256, proof: &ZkProof) -> Result<bool, Error> {
@@ -676,20 +646,24 @@ impl MetaMultiSigWallet {
         leaf_pre.extend_from_slice(inputs_hash.as_slice());
         let leaf = keccak(&leaf_pre);
 
-        let verifier = IVerifyProofAggregation::new(self.zkv_contract.get());
-        let merkle_path: Vec<B256> = proof.zkMerklePath.clone();
-        verifier
-            .verify_proof_aggregation(
-                self.vm(),
-                Call::new(),
-                proof.domainId,
-                proof.aggregationId,
-                leaf,
-                merkle_path,
-                proof.leafCount,
-                proof.index,
-            )
-            .map_err(|_| err("Verifier call failed"))
+        // verifyProofAggregation(uint256,uint256,bytes32,bytes32[],uint256,uint256)
+        // Head is 6 words; the bytes32[] is at offset 0xC0, then length + elements.
+        let mp = &proof.zkMerklePath;
+        let mut cd = Vec::with_capacity(4 + 32 * 7 + 32 * mp.len());
+        cd.extend_from_slice(&[0xa7, 0x8f, 0x9e, 0x36]);
+        cd.extend_from_slice(&proof.domainId.to_be_bytes::<32>());
+        cd.extend_from_slice(&proof.aggregationId.to_be_bytes::<32>());
+        cd.extend_from_slice(leaf.as_slice());
+        cd.extend_from_slice(&U256::from(0xC0).to_be_bytes::<32>());
+        cd.extend_from_slice(&proof.leafCount.to_be_bytes::<32>());
+        cd.extend_from_slice(&proof.index.to_be_bytes::<32>());
+        cd.extend_from_slice(&U256::from(mp.len()).to_be_bytes::<32>());
+        for w in mp.iter() {
+            cd.extend_from_slice(w.as_slice());
+        }
+        let ret = static_call(self.vm(), Call::new(), self.zkv_contract.get(), &cd)
+            .map_err(|_| err("Verifier call failed"))?;
+        Ok(ret.len() == 32 && ret[31] != 0)
     }
 }
 

--- a/packages/stylus/src/lib.rs
+++ b/packages/stylus/src/lib.rs
@@ -692,3 +692,136 @@ impl MetaMultiSigWallet {
             .map_err(|_| err("Verifier call failed"))
     }
 }
+
+// ============================================================================
+// Unit tests — exercise the execute() self-call dispatcher in isolation.
+//
+// The reported bug: add/remove signer and updateSignaturesRequired submitted
+// through execute() reverted, while batchTransfer worked. execute() routes a
+// self-call (to == address(this)) through dispatch_self_call(), which selects
+// the onlySelf *_internal helper by 4-byte selector and hand-rolls the
+// Solidity ABI decode (no full alloy codec, to keep WASM size down). These
+// tests feed canonical ABI-encoded calldata straight into dispatch_self_call
+// and assert the storage mutation, covering exactly the decode + routing path
+// that was suspected broken. The ZK-proof gating in execute() is orthogonal
+// (it only guards entry) so it is not needed here.
+// ============================================================================
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use stylus_sdk::testing::*;
+
+    fn word(v: U256) -> [u8; 32] {
+        v.to_be_bytes::<32>()
+    }
+
+    // ABI-encode `f(uint256[],uint256)` calldata (addSigners / removeSigners).
+    fn calldata_u256arr_u256(selector: [u8; 4], arr: &[U256], tail: U256) -> Vec<u8> {
+        let mut d = Vec::from(selector);
+        d.extend_from_slice(&word(U256::from(0x40))); // offset to the array
+        d.extend_from_slice(&word(tail)); // the static uint256
+        d.extend_from_slice(&word(U256::from(arr.len())));
+        for c in arr {
+            d.extend_from_slice(&word(*c));
+        }
+        d
+    }
+
+    // ABI-encode `updateSignaturesRequired(uint256)` calldata.
+    fn calldata_update_sig(sig: U256) -> Vec<u8> {
+        let mut d = vec![0x30, 0x34, 0xa7, 0x42];
+        d.extend_from_slice(&word(sig));
+        d
+    }
+
+    fn fresh_wallet(vm: &TestVM, commitments: &[U256], sig_required: u64) -> MetaMultiSigWallet {
+        let mut c = MetaMultiSigWallet::from(vm);
+        let r = c.initialize_state(
+            Address::from([0x11; 20]), // zkv (non-zero)
+            B256::ZERO,
+            Address::from([0x22; 20]), // poseidon (non-zero)
+            U256::from(421614),
+            commitments.to_vec(),
+            U256::from(sig_required),
+        );
+        assert!(r.is_ok(), "init failed");
+        c
+    }
+
+    fn read_commitments(c: &MetaMultiSigWallet) -> Vec<U256> {
+        let len = c.commitments.len();
+        (0..len).map(|i| c.commitments.get(i).unwrap()).collect()
+    }
+
+    #[test]
+    fn add_signers_via_dispatch_updates_storage() {
+        let vm = TestVM::default();
+        let mut c = fresh_wallet(&vm, &[U256::from(11), U256::from(22)], 1);
+
+        // addSigners([33], 2) — selector 0xa8d2c852
+        let data = calldata_u256arr_u256([0xa8, 0xd2, 0xc8, 0x52], &[U256::from(33)], U256::from(2));
+        assert!(c.dispatch_self_call(&data).is_ok(), "addSigners dispatch");
+
+        assert_eq!(read_commitments(&c), vec![U256::from(11), U256::from(22), U256::from(33)]);
+        assert_eq!(c.signatures_required.get(), U256::from(2));
+    }
+
+    #[test]
+    fn remove_signers_via_dispatch_updates_storage() {
+        let vm = TestVM::default();
+        let mut c = fresh_wallet(&vm, &[U256::from(11), U256::from(22), U256::from(33)], 1);
+
+        // removeSigners([22], 2) — selector 0x4791ca34. Internal uses swap-with-last + pop.
+        let data = calldata_u256arr_u256([0x47, 0x91, 0xca, 0x34], &[U256::from(22)], U256::from(2));
+        assert!(c.dispatch_self_call(&data).is_ok(), "removeSigners dispatch");
+
+        let got = read_commitments(&c);
+        assert_eq!(got.len(), 2);
+        assert!(got.contains(&U256::from(11)) && got.contains(&U256::from(33)));
+        assert!(!got.contains(&U256::from(22)));
+        assert_eq!(c.signatures_required.get(), U256::from(2));
+    }
+
+    #[test]
+    fn update_signatures_required_via_dispatch() {
+        let vm = TestVM::default();
+        let mut c = fresh_wallet(&vm, &[U256::from(11), U256::from(22), U256::from(33)], 1);
+
+        assert!(
+            c.dispatch_self_call(&calldata_update_sig(U256::from(3))).is_ok(),
+            "updateSignaturesRequired dispatch",
+        );
+        assert_eq!(c.signatures_required.get(), U256::from(3));
+    }
+
+    #[test]
+    fn update_signatures_required_rejects_above_signer_count() {
+        let vm = TestVM::default();
+        let mut c = fresh_wallet(&vm, &[U256::from(11), U256::from(22)], 1);
+
+        // 3 > 2 signers must revert and leave signatures_required untouched.
+        let res = c.dispatch_self_call(&calldata_update_sig(U256::from(3)));
+        assert!(res.is_err());
+        assert_eq!(c.signatures_required.get(), U256::from(1));
+    }
+
+    #[test]
+    fn add_signers_rejects_duplicate_commitment() {
+        let vm = TestVM::default();
+        let mut c = fresh_wallet(&vm, &[U256::from(11), U256::from(22)], 1);
+
+        // 22 already a signer -> "Commitment exists".
+        let data = calldata_u256arr_u256([0xa8, 0xd2, 0xc8, 0x52], &[U256::from(22)], U256::from(2));
+        assert!(c.dispatch_self_call(&data).is_err());
+        assert_eq!(read_commitments(&c).len(), 2);
+    }
+
+    #[test]
+    fn unknown_selector_is_rejected() {
+        let vm = TestVM::default();
+        let mut c = fresh_wallet(&vm, &[U256::from(11), U256::from(22)], 1);
+
+        let data = vec![0xde, 0xad, 0xbe, 0xef, 0x00, 0x00, 0x00, 0x00];
+        assert!(c.dispatch_self_call(&data).is_err());
+    }
+}


### PR DESCRIPTION
## Summary

Adds Arbitrum One (42161) mainnet support with the Stylus (Rust/WASM) account contract, and slims the Stylus impl so it deploys on Arbitrum One **today** — no need to wait for ArbOS 60.

## Background

The full impl was 31202 bytes (2 fragments), over Arbitrum One's 24576-byte (24 KiB) Stylus code-size limit, so it only deployed on Arbitrum Sepolia (which already has ArbOS 60). Slimmed to **24295 bytes (1 fragment)** to fit Arbitrum One's current limit.

## How it was slimmed

- **Drop on-chain events** (Deposit / TransactionExecuted / Owner). The app tracks transactions via the backend DB + relayer, not on-chain logs, so no functional impact. Largest saving (~6 KB of alloy event encoding for dynamic bytes).
- **Hand-roll PoseidonT3 + zkVerify STATICCALLs** instead of `sol_interface!` bindings (internal only, no ABI change).

Kept unchanged: `execute` (same ABI, `ZkProof[]`), transfer, batch, signer management, getters, proof verification. No backend/frontend changes required.

## Wiring (42161)

shared (chain def, contracts-config, STYLUS_CHAIN_IDS, USDC, `CHAIN_IDS` single source), backend (`proof.ts` domain 10 — verified, `campaign.ts`), frontend (scaffold.config, network meta, NetworkChooserSidebar, ChooseNetwork).

## Deployed + tested

Deployed and tested (transfer + batch) on both chains:

| Chain | Impl | Factory |
|---|---|---|
| Arbitrum Sepolia (421614) | `0x61fddf7cde02d4527b7d1086671d3f948e59f1d1` | `0x73d33f803600087ed1259035f9ff46f16f15c11a` |
| Arbitrum One (42161) | `0x49e772bd7efd483c043402331fbf03533852850f` | `0x740b6a46585474eb113f81999c1117e69d4be1be` |

On-chain account verified on Arbitrum One (3 actions executed): https://arbiscan.io/address/0xdc485d168ed61c439c18b7adb44a74aee21042cd

## Revert plan

Slimming is temporary. When ArbOS 60 lands on Arbitrum One (`stylusVersion()` returns 3, the limit is raised), restore the on-chain events and redeploy the full impl. See `packages/stylus/NOTES.md`.