### PR TITLE
ci: auto-review every PR with Claude

### DIFF
--- a/.github/workflows/claude-review.yaml
+++ b/.github/workflows/claude-review.yaml
@@ -1,0 +1,76 @@
+name: Claude PR Review
+
+# Runs an automated Claude code review on every pull request targeting main or
+# develop. Findings are posted as PR comments (top-level summary + inline notes).
+#
+# Prerequisites (one-time, set by a maintainer):
+#   1. Install the Claude GitHub App on the Poly-pay/polypay_app repo:
+#        https://github.com/apps/claude
+#   2. Add the repo/Actions secret ANTHROPIC_API_KEY (Settings → Secrets and
+#      variables → Actions). Alternatively swap to claude_code_oauth_token.
+# Until both are in place the job runs but cannot authenticate.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches:
+      - main
+      - develop
+
+# Keep only the latest review per PR; cancel superseded runs on new pushes.
+concurrency:
+  group: claude-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Claude review
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          track_progress: true
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
+            Review this pull request's diff. Report correctness bugs first, then
+            reuse / simplification / efficiency cleanups. The PR branch is
+            already checked out in the working directory; read CLAUDE.md for the
+            repo's conventions.
+
+            PolyPay is a privacy-preserving payroll & multisig platform
+            (Next.js 15 + NestJS 11 + Hardhat + Prisma + Noir/ZK). Weight the
+            review toward:
+            - Security: this app moves USDC and handles multisig approvals, ZK
+              proofs, JWT auth, and x402 / EIP-3009 signatures. Scrutinise any
+              change touching signatures, key material, auth, access control, or
+              fund movement. Never approve committed secrets.
+            - Convention adherence (per CLAUDE.md): API contracts via
+              @polypay/shared DTOs, all HTTP through apiClient, Zod schemas for
+              forms, useAuthenticatedQuery for authed queries, no hardcoded API
+              URLs, business logic in hooks not components.
+            - Bugs a careful reviewer catches in one sitting: inverted/wrong
+              conditions, missing await, null/undefined derefs, off-by-one,
+              swallowed errors in catch, copy-paste of the wrong variable, call
+              sites broken by a changed signature or return shape.
+
+            Be specific and actionable; cite file:line. If the diff is clean,
+            say so briefly rather than inventing issues.
+
+            Use `gh pr comment` for the top-level summary.
+            Use `mcp__github_inline_comment__create_inline_comment` (with
+            `confirmed: true`) for line-level issues.
+            Only post GitHub comments — do not return review text as messages.
+          claude_args: |
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"

--- a/.github/workflows/claude-review.yaml
+++ b/.github/workflows/claude-review.yaml
@@ -6,9 +6,12 @@ name: Claude PR Review
 # Prerequisites (one-time, set by a maintainer):
 #   1. Install the Claude GitHub App on the Poly-pay/polypay_app repo:
 #        https://github.com/apps/claude
-#   2. Add the repo/Actions secret ANTHROPIC_API_KEY (Settings → Secrets and
-#      variables → Actions). Alternatively swap to claude_code_oauth_token.
+#   2. Generate a token from a Claude Pro/Max subscription (`claude setup-token`)
+#      and add it as the repo/Actions secret CLAUDE_CODE_OAUTH_TOKEN (Settings →
+#      Secrets and variables → Actions).
 # Until both are in place the job runs but cannot authenticate.
+# Note: subscription-token usage counts against the account's Claude usage
+# limits. For a high-PR repo, an ANTHROPIC_API_KEY (API billing) avoids that.
 
 on:
   pull_request:
@@ -38,7 +41,7 @@ jobs:
       - name: Claude review
         uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           track_progress: true
           prompt: |
             REPO: ${{ github.repository }}


### PR DESCRIPTION
## What

Adds `.github/workflows/claude-review.yaml` — a `pull_request`-triggered workflow that runs an automated Claude code review on **every PR to `main` or `develop`** and posts findings as PR comments (top-level summary + inline line notes).

Event-driven: fires the moment a PR is opened, updated, or reopened — no polling, no open session required.

## Details

- **Triggers**: `opened`, `synchronize`, `reopened` on PRs into `main`/`develop`.
- **Auth**: `claude_code_oauth_token` — runs on the team's Claude Pro/Max subscription (no separate API billing).
- **Review focus**: security-weighted for this payments / multisig / ZK codebase (signatures, key material, auth, fund movement, x402/EIP-3009), plus CLAUDE.md convention adherence and ordinary correctness bugs.
- **Tooling**: scoped to `gh pr comment/diff/view` + inline-comment MCP only.
- **Concurrency**: one review per PR; superseded runs cancel on new pushes.
- Uses `actions/checkout@v4` to match the existing workflows.

## Required before this works (maintainer, one-time)

1. **Install the Claude GitHub App** on `Poly-pay/polypay_app`: https://github.com/apps/claude — *(done)*
2. **Generate a subscription token** with `claude setup-token` and add it as the `CLAUDE_CODE_OAUTH_TOKEN` Actions secret (Settings → Secrets and variables → Actions).

> Note: subscription-token usage counts against the account's Claude usage limits. For a high-PR repo, swapping back to an `ANTHROPIC_API_KEY` (API billing) avoids that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
