### PR TITLE
ci: add on-demand @claude workflow (subscription OAuth, no API billing)

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,46 @@
+name: Claude
+
+# On-demand assistant. Runs ONLY when someone writes "@claude" in an issue or PR
+# comment/review. Nothing runs automatically, so usage stays within the team's
+# Claude Pro/Max subscription (auth via CLAUDE_CODE_OAUTH_TOKEN — no API billing).
+#
+# Prerequisites (already in place):
+#   1. Claude GitHub App installed on Poly-pay/polypay_app (https://github.com/apps/claude)
+#   2. CLAUDE_CODE_OAUTH_TOKEN Actions secret (`claude setup-token`, Pro/Max subscription)
+#
+# Do NOT add `anthropic_api_key` here — that triggers pay-per-use API billing on
+# top of the subscription, which we explicitly do not want.
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
+  issues:
+    types: [opened, assigned]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
## What

Adds `.github/workflows/claude.yml` — an **on-demand** Claude assistant that runs **only** when someone writes `@claude` in an issue or PR comment/review.

## Why

The previous auto-review workflow (#297) ran on **every PR**, which burned through the team's Claude Pro/Max usage limits — so it was removed in `ea307e6`. This version runs nothing automatically: it fires solely on an explicit `@claude` mention, keeping usage within the subscription.

## Cost / auth

- Auth via `CLAUDE_CODE_OAUTH_TOKEN` (already set as an Actions secret) — runs on the Pro/Max **subscription**.
- **No `anthropic_api_key`** — that path is pay-per-use API billing on top of the subscription, which we explicitly do not want.

## Prerequisites (already in place)

- ✅ Claude GitHub App installed on the repo
- ✅ `CLAUDE_CODE_OAUTH_TOKEN` secret

## Test

After merge, comment `@claude summarize this PR` on any PR/issue and confirm the **Claude** workflow run appears under Actions and authenticates. Confirm no run fires on a plain PR open/push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)